### PR TITLE
Rename merge queue pipeline, add a dummy pipeline for PRs

### DIFF
--- a/.github/workflows/dummy_pr.yml
+++ b/.github/workflows/dummy_pr.yml
@@ -1,0 +1,24 @@
+name: PR Dummy Pipeline
+
+on:
+  pull_request:
+  
+
+env:
+  POETRY_VIRTUALENVS_IN_PROJECT: "true"
+  # Force nox to produce colorful logs:
+  FORCE_COLOR: "true"
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: /usr/bin/true
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: /usr/bin/true
+  Docs:
+    runs-on: ubuntu-latest
+    steps:
+      - run: /usr/bin/true

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -1,4 +1,4 @@
-name: Push Pipeline
+name: Merge Queue Pipeline
 
 on:
   merge_group:


### PR DESCRIPTION
See https://github.com/opendp/tumult-analytics/issues/1#issuecomment-2936533302 for the full rationale. This should allow us to make the Lint, Test, and Docs jobs required checks without blocking PRs from joining the merge queue.