### PR TITLE
Fix version switcher json url

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -115,7 +115,7 @@ nitpick_ignore = [
 # Remove this after intersphinx can use core
 nitpick_ignore_regex = [(r"py:.*", r"tmlt.core.*")]
 
-json_url = "https://docs.tmlt.dev/analytics/versions.json"
+json_url = "https://opendp.github.io/tumult-docs/analytics/versions.json"
 
 # Theme settings
 templates_path = ["_templates", "_templates/autosummary"]


### PR DESCRIPTION
This ensures that newly built docs will point to the right version switcher json file without having to do another massive find/replace.