### PR TITLE
Remove unnecessary checkout from setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,8 +3,6 @@ description: 'Initialize a github actions runner for Analytics CI jobs.'
 runs:
   using: "composite"
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
The repository must already be checked out to use the action, so this is pointless. And worse, if the repository is checked out into a non-default location, this runs the risk of overwriting it when it uses the default location.