### PR TITLE
Fix version switcher

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,6 +20,8 @@ copyright = "2025"
 # necessarily the name of the package as pip understands it.
 package_name = "tmlt"
 
+default_branch = "main"
+
 ### Build information
 
 pipeline_type = os.getenv("GITHUB_REF_TYPE")
@@ -33,6 +35,8 @@ ref_name = os.getenv("GITHUB_REF_NAME")
 if pipeline_type and pipeline_type == "tag" and "-" not in ref_name:
     release = ref_name
     version = "v" + ".".join(ref_name.split(".")[:2])
+elif ref_name and ref_name == default_branch:
+    release = version = "dev"
 else:
     release = version = ref_name or "HEAD"
 


### PR DESCRIPTION
Even though this latest version of the code is now built from the `main` branch, it's still referred to as `dev` on the docs site. If we write `main` into the version files, the version switcher will not display the correct version when viewing the dev docs (see attached screenshot).
<img width="422" alt="Screenshot 2025-06-25 at 11 14 22 AM" src="https://github.com/user-attachments/assets/34f9d3cd-2780-4d09-b69d-478e321730ea" />