### PR TITLE
Update versions json url and fix docs job

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -54,6 +54,9 @@ jobs:
           path: tumult-docs
       - run: rm -r tumult-docs/docs/analytics/dev
       - run: mv public tumult-docs/docs/analytics/dev
+      - name: update version information
+        working-directory: tumult-docs
+        run: python update-versions.py docs/analytics/
       - name: commit to docs repo
         working-directory: tumult-docs
         env:
@@ -61,7 +64,7 @@ jobs:
         run: |
           git config user.name "docs-bot"
           git config user.email "87283505+opendp-dev@users.noreply.github.com"
-          git add docs/analytics/dev
+          git add docs/analytics
           git commit -m "[auto] Publish docs for dev ($COMMIT)"
           git push
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -121,7 +121,7 @@ nitpick_ignore = [
 # Remove this after intersphinx can use core
 nitpick_ignore_regex = [(r"py:.*", r"tmlt.core.*")]
 
-json_url = "https://opendp.github.io/tumult-docs/analytics/versions.json"
+json_url = "https://tmlt.dev/analytics/versions.json"
 
 # Theme settings
 templates_path = ["_templates", "_templates/autosummary"]


### PR DESCRIPTION
- Update the url for the versions json file, now that we're on tmlt.dev
- Run the version updater script as part of the docs push job.

Tested in this branch: https://github.com/opendp/tumult-docs/compare/prod...dasm/docs-test