### PR TITLE
Fix doc breakages

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,6 +50,7 @@ build_time = datetime.datetime.utcnow().isoformat(sep=" ", timespec="minutes")
 linkcheck_ignore = [
     "https://colab.research.google.com/drive/1hIbp7y1uXIXc-MeiCAV4_0EwgSZzoM8U#offline=true&sandboxMode=true",
     "https://docs.databricks.com/release-notes/runtime/releases.html",
+    "http://creativecommons.org/licenses/by-sa/4.0/",
 ]
 
 ### Sphinx configuration

--- a/doc/deployment/troubleshooting.rst
+++ b/doc/deployment/troubleshooting.rst
@@ -101,5 +101,5 @@ function have *any* references to Spark objects, the map function will succeed:
 Having problems with something else?
 ------------------------------------
 
-Ask for help on `our Slack server <https://www.tmlt.dev/slack>`_ in the
+Ask for help on `our Slack server <https://join.slack.com/t/opendp/shared_invite/zt-1aca9bm7k-hG7olKz6CiGm8htI2lxE8w>`_ in the
 **#library-questions** channel!

--- a/doc/topic-guides/understanding-sensitivity.rst
+++ b/doc/topic-guides/understanding-sensitivity.rst
@@ -225,8 +225,8 @@ post`_.
 
 While this topic guide covers the most common cases of sensitivity tracking in Tumult
 Analytics, it is certainly not exhaustive. If you have additional questions, feel free
-to reach out to us on `our Slack server <https://www.tmlt.dev/slack>`_ in the
-**#library-questions** channel!
+to reach out to us on 
+`our Slack server <https://join.slack.com/t/opendp/shared_invite/zt-1aca9bm7k-hG7olKz6CiGm8htI2lxE8w>`_!
 
 .. _blog post: https://desfontain.es/privacy/gaussian-noise.html
 

--- a/doc/tutorials/clamping-bounds.rst
+++ b/doc/tutorials/clamping-bounds.rst
@@ -33,7 +33,7 @@ The setup process is the same as in the earlier tutorials.
 
    spark = SparkSession.builder.getOrCreate()
    spark.sparkContext.addFile(
-       "https://tumult-public.s3.amazonaws.com/library-members.csv"
+       "https://raw.githubusercontent.com/opendp/tumult-demo-data/refs/heads/main/library-members.csv"
    )
    members_df = spark.read.csv(
       SparkFiles.get("library-members.csv"), header=True, inferSchema=True

--- a/doc/tutorials/first-steps.rst
+++ b/doc/tutorials/first-steps.rst
@@ -61,7 +61,7 @@ repository, and load it into a Spark :class:`~pyspark.sql.DataFrame`.
 .. testcode::
 
    spark.sparkContext.addFile(
-       "https://tumult-public.s3.amazonaws.com/library-members.csv"
+       "https://raw.githubusercontent.com/opendp/tumult-demo-data/refs/heads/main/library-members.csv"
    )
    members_df = spark.read.csv(
        SparkFiles.get("library-members.csv"), header=True, inferSchema=True

--- a/doc/tutorials/groupby-queries.rst
+++ b/doc/tutorials/groupby-queries.rst
@@ -78,7 +78,7 @@ infinite privacy budget—not to be used in production!
 
    spark = SparkSession.builder.getOrCreate()
    spark.sparkContext.addFile(
-       "https://tumult-public.s3.amazonaws.com/library-members.csv"
+       "https://raw.githubusercontent.com/opendp/tumult-demo-data/refs/heads/main/library-members.csv"
    )
    members_df = spark.read.csv(
        SparkFiles.get("library-members.csv"), header=True, inferSchema=True

--- a/doc/tutorials/more-with-privacy-ids.rst
+++ b/doc/tutorials/more-with-privacy-ids.rst
@@ -43,10 +43,10 @@ as well as the library members dataset used in all other tutorials:
 
     spark = SparkSession.builder.getOrCreate()
     spark.sparkContext.addFile(
-        "https://tumult-public.s3.amazonaws.com/checkout-logs.csv"
+        "https://media.githubusercontent.com/media/opendp/tumult-demo-data/refs/heads/main/checkout-logs.csv"
     )
     spark.sparkContext.addFile(
-        "https://tumult-public.s3.amazonaws.com/library-members.csv"
+        "https://raw.githubusercontent.com/opendp/tumult-demo-data/refs/heads/main/library-members.csv"
     )
     checkouts_df = spark.read.csv(
         SparkFiles.get("checkout-logs.csv"), header=True, inferSchema=True

--- a/doc/tutorials/privacy-budget-basics.rst
+++ b/doc/tutorials/privacy-budget-basics.rst
@@ -60,7 +60,7 @@ Just like earlier, we import Python packages...
 
    spark = SparkSession.builder.getOrCreate()
    spark.sparkContext.addFile(
-       "https://tumult-public.s3.amazonaws.com/library-members.csv"
+       "https://raw.githubusercontent.com/opendp/tumult-demo-data/refs/heads/main/library-members.csv"
    )
    members_df = spark.read.csv(
        SparkFiles.get("library-members.csv"), header=True, inferSchema=True

--- a/doc/tutorials/privacy-id-basics.rst
+++ b/doc/tutorials/privacy-id-basics.rst
@@ -58,10 +58,10 @@ Notice that the *same member* may have checked out *many books*, as illustrated 
 
     spark = SparkSession.builder.getOrCreate()
     spark.sparkContext.addFile(
-        "https://tumult-public.s3.amazonaws.com/checkout-logs.csv"
+        "https://media.githubusercontent.com/media/opendp/tumult-demo-data/refs/heads/main/checkout-logs.csv"
     )
     spark.sparkContext.addFile(
-        "https://tumult-public.s3.amazonaws.com/library_books.csv"
+        "https://raw.githubusercontent.com/opendp/tumult-demo-data/refs/heads/main/library_books.csv"
     )
     checkouts_df = spark.read.csv(
         SparkFiles.get("checkout-logs.csv"), header=True, inferSchema=True

--- a/doc/tutorials/simple-transformations.rst
+++ b/doc/tutorials/simple-transformations.rst
@@ -34,7 +34,7 @@ As usual, we need to create a Session with our dataset.
 
     spark = SparkSession.builder.getOrCreate()
     spark.sparkContext.addFile(
-        "https://tumult-public.s3.amazonaws.com/library-members.csv"
+        "https://raw.githubusercontent.com/opendp/tumult-demo-data/refs/heads/main/library-members.csv"
     )
     members_df = spark.read.csv(
        SparkFiles.get("library-members.csv"), header=True, inferSchema=True
@@ -419,7 +419,7 @@ ZIP code.
 
     # ZIP code data is based on https://worldpopulationreview.com/zips/north-carolina
     spark.sparkContext.addFile(
-        "https://tumult-public.s3.amazonaws.com/nc-zip-codes.csv"
+        "https://raw.githubusercontent.com/opendp/tumult-demo-data/refs/heads/main/nc-zip-codes.csv"
     )
     nc_zip_df = spark.read.csv(
        SparkFiles.get("nc-zip-codes.csv"), header=True, inferSchema=True


### PR DESCRIPTION
A number of links in the docs have stopped working:
- Swapping the tmlt.dev url to point at us revealed a couple of links to the old tumult slack that we missed.
- When we reverted the docs to the pre-split versions, we forgot to back-port the change to using demo data from git rather than s3. The Tumult s3 bucket no longer appears to exist, so none of that data still exists.
- In an unrelated change, the creative commons site seems to be blocking sphinx now, so I added it to the ignore list.

Rather than using the Tumult-hosted demo data, I uploaded it to https://github.com/opendp/tumult-demo-data/. Unfortunately, all of the versions of the checkouts dataset are bigger than the github filesize limit (~190MB > 100MB), so they're stored using [git lfs](https://git-lfs.com/) (which is why they have a slightly different link structure.