### PR TITLE
Use a composite action for docs pushes

### DIFF
--- a/.github/actions/push_docs/action.yml
+++ b/.github/actions/push_docs/action.yml
@@ -1,0 +1,57 @@
+name: 'Push Docs'
+description: 'Build the docs in the current repository, and push it to another.'
+inputs:
+  docs-repository:
+    description: The organization/name of the docs repository.
+    required: true
+  docs-repository-token:
+    description: A token that grants read/write access to the docs repository.
+    required: true
+  docs-path:
+    description: The path to the current set of docs (e.g. core vs analytics) within the docs repository.
+    required: true
+  version:
+    description: The version of the docs to push to.
+    required: true
+  dry-run:
+    description: If true, pushes to a new branch rather than the default branch.
+    required: false
+    default: false
+runs:
+  using: composite
+  steps:
+    - name: Get commit
+      id: commit
+      run: echo "COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      shell: bash
+    - run: uv run nox -s docs
+      shell: bash
+    - run: rm -r public/.doctrees
+      shell: bash
+    - name: Checkout docs repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.docs-repository }}
+        token: ${{ inputs.docs-repository-token }}
+        path: docs-repo
+    - run: rm -r docs-repo/${{ inputs.docs-path }}/${{ inputs.version }}
+      shell: bash
+    - run: mv public docs-repo/${{ inputs.docs-path }}/${{ inputs.version }}
+      shell: bash
+    - name: update version information
+      working-directory: docs-repo
+      run: python update-versions.py ${{ inputs.docs-path }}/
+      shell: bash
+    - name: commit to docs repo
+      working-directory: docs-repo
+      env:
+        COMMIT: ${{ steps.commit.outputs.COMMIT}}
+      run: |
+        git config user.name "docs-bot"
+        git config user.email "87283505+opendp-dev@users.noreply.github.com"
+        git config --global push.autoSetupRemote true
+        if [ ${{ inputs.dry-run }} ]; then git checkout -b dry-run/$COMMIT; fi
+        git add ${{ inputs.docs-path }}
+        git commit -m "[auto] Publish docs for ${{ inputs.version }} ($COMMIT)"
+        git push
+      shell: bash

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - 'main'
 
+
 env:
   # Force nox to produce colorful logs:
   FORCE_COLOR: "true"
@@ -40,29 +41,10 @@ jobs:
         with:
           name: dist
           path: dist
-      - name: Get commit
-        id: commit
-        run: echo "COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-      - run: uv run nox -s docs
-      - run: rm -r public/.doctrees
-      - name: Checkout docs repository
-        uses: actions/checkout@v4
+      - name: Push docs
+        uses: ./.github/actions/push_docs
         with:
-          repository: 'opendp/tumult-docs'
-          token: ${{ secrets.DOCS_REPO_PAT}}
-          path: tumult-docs
-      - run: rm -r tumult-docs/docs/analytics/dev
-      - run: mv public tumult-docs/docs/analytics/dev
-      - name: update version information
-        working-directory: tumult-docs
-        run: python update-versions.py docs/analytics/
-      - name: commit to docs repo
-        working-directory: tumult-docs
-        env:
-          COMMIT: ${{ steps.commit.outputs.COMMIT}}
-        run: |
-          git config user.name "docs-bot"
-          git config user.email "87283505+opendp-dev@users.noreply.github.com"
-          git add docs/analytics
-          git commit -m "[auto] Publish docs for dev ($COMMIT)"
-          git push
+          docs-repository: opendp/tumult-docs
+          docs-repository-token: ${{ secrets.DOCS_REPO_PAT }}
+          docs-path: docs/analytics
+          version: dev


### PR DESCRIPTION
The first step in sharing this code between Analytics and Core, and fixing https://github.com/opendp/tumult-core/issues/6

As a next step, I will move this to the tools repository.

This also parameterizes a lot of previously-hardcoded values so it can be used for both Core and Analytics, and for pushing versions other than dev.

You can see a test of the dry run functionality here: https://github.com/opendp/tumult-docs/tree/dry-run/6fced96