### PR TITLE
Switch to docs.tmlt.dev for versions json

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -122,7 +122,7 @@ nitpick_ignore = [
 # Remove this after intersphinx can use core
 nitpick_ignore_regex = [(r"py:.*", r"tmlt.core.*")]
 
-json_url = "https://tmlt.dev/analytics/versions.json"
+json_url = "https://docs.tmlt.dev/analytics/versions.json"
 
 # Theme settings
 templates_path = ["_templates", "_templates/autosummary"]


### PR DESCRIPTION
This is a necessary part of switching to serving our docs from docs.tmlt.dev, per github.com/opendp/tumult-docs/issues/13