### PR TITLE
Fix release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release Pipeline
 on:
   push:
     tags:
+      - '**'
 
 
 env:


### PR DESCRIPTION
Apparently the way I had it before runs on branches too, while this version should only run on tags. See https://github.com/opendp/tumult-analytics/actions/runs/16888553912, e.g.