### PR TITLE
Elaborates Contribution instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,16 @@
 
 We are happy to accept external contributions! 💖
 
-## Contact
-
 First, let us know what you would like to contribute. Feel free to:
 
-- report a bug or request a feature on [GitHub](https://github.com/opendp/tumult-analytics/issues);
+- report a bug or request a feature by filing an issue on our [GitHub](https://github.com/opendp/tumult-analytics/issues);
 - send general queries to info@opendp.org, or email security@opendp.org if it is related to security;
-- ask any question on our [Slack][slack] instance.
+- ask any question on our [Slack][slack] instance. Tumult Analytics maintainers are active on most of the public channels, the `lib-dev` and `lib-support` channels are a great place to start interacting with the development community.
 
 [slack]: https://join.slack.com/t/opendp/shared_invite/zt-1aca9bm7k-hG7olKz6CiGm8htI2lxE8w
+
+
+Second, anyone can send us a Pull Request from a forked repo per Github's [documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork). Ideally Pull Requests are linked to an issue so the maintainers can easily understand the problem being solved. We try to link all Pull Requests to issues ourselves, so creating and commenting on issues is an easy way to get involved.
 
 ## Local development
 


### PR DESCRIPTION
This provides more detailed instructions to the Tumult Analytics community on how to get involved with Tumult Analytics development. 

Issue on Contribution Instructions: https://github.com/opendp/tumult-analytics/issues/36