### PR TITLE
Add an anti-footgun option to dynamic versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ style = "semver"
 # The default configuration expect vX.Y.Z, but we haven't been using the 'v' prefix.
 pattern = "^(?P<base>\\d+\\.\\d+\\.\\d+)(-(?P<stage>[a-zA-Z]+)\\.(?P<revision>\\d+))?"
 commit-length = 8
+latest-tag = true
 
 [tool.hatch.build.hooks.version]
 path = "src/tmlt/analytics/_version.py"


### PR DESCRIPTION
At present, running `make package` creates files whose version number was totally absurd e.g. "0.8.2.post549+a3115dcb". ~~My understanding is that this is because it would go through all existing tags and find the "latest" one… by alphabetical order.~~ (Edit: this is not the correct explanation, see below.) So even if the current git tag is something like "0.20.2-rc.1" it would ignore it. Worse, if the current git tag is not recognized by our regex (say, because someone naively named it "v0.20.2-rc.1"), it would be silently ignored.

This option tell it to just look at the last git tag, which solves both problems: it prevents it from looking at old stuff, and if the last git tag doesn't pass the regex test, it fails with a clear error message, so we immediately know what's going on.

Note: I'm not sure why it ever worked before, my guess is that the behavior of some tool changed between versions. But I think we want that option regardless.