### PR TITLE
Switch to bar syntax for unions in our docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -97,6 +97,9 @@ autodoc_default_options = {
     "show-inheritance": True,
 }
 
+# Autodoc typehints settings
+always_use_bars_union = True
+
 # General settings
 master_doc = "index"
 exclude_patterns = ["templates"]


### PR DESCRIPTION
See https://github.com/opendp/tumult-core/pull/38

Looks like analytics has the exact same problem, we just haven't noticed yet.