### PR TITLE
Make the merge queue fail immediately if linting fails

### DIFF
--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -42,7 +42,9 @@ jobs:
       - run: uv run nox -t lint
   Test:
     runs-on: ubuntu-latest
-    needs: Package
+    needs:
+      - Package
+      - Lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -56,7 +58,9 @@ jobs:
       - run: uv run nox -s smoketest test-doctest test-fast
   Docs:
     runs-on: ubuntu-latest
-    needs: Package
+    needs:
+      - Package
+      - Lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This only has a minor impact on dev experience (if both lint and tests/docs fail, you only hear about the latter when you re-try merging). But one Should™ check all that locally to avoid spending too many CI minutes, so linting failures indicate "you should re-check stuff locally", and there's no need to then run more expensive processes like tests and docs.