### PR TITLE
remove EnforceConstraints.options

### DIFF
--- a/src/tmlt/analytics/_query_expr.py
+++ b/src/tmlt/analytics/_query_expr.py
@@ -1468,11 +1468,6 @@ class EnforceConstraint(QueryExpr):
     """The QueryExpr to which the constraint will be applied."""
     constraint: Constraint
     """A constraint to be enforced."""
-    options: FrozenDict = FrozenDict.from_dict({})
-    """Options to be used when enforcing the constraint.
-
-    Appropriate values here vary depending on the constraint. These options are
-    to support advanced use cases, and generally should not be used."""
 
     def _validate(self, input_schema: Schema):
         """Validation checks for this QueryExpr."""

--- a/src/tmlt/analytics/_query_expr_compiler/_base_transformation_visitor.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_base_transformation_visitor.py
@@ -1556,9 +1556,7 @@ class BaseTransformationVisitor(QueryExprVisitor):
             expr.child
         )
         # pylint: disable=protected-access
-        transformation, ref = expr.constraint._enforce(
-            child_transformation, child_ref, *expr.options
-        )
+        transformation, ref = expr.constraint._enforce(child_transformation, child_ref)
         # pylint: enable=protected-access
         return self.Output(
             transformation,

--- a/src/tmlt/analytics/constraints/_truncation.py
+++ b/src/tmlt/analytics/constraints/_truncation.py
@@ -146,7 +146,7 @@ class MaxRowsPerID(Constraint):
 
         else:
 
-            def gen_tranformation_ark(parent_domain, parent_metric, target):
+            def gen_transformation_ark(parent_domain, parent_metric, target):
                 return LimitRowsPerGroupValue(
                     parent_domain, parent_metric, child_ref.identifier, target, self.max
                 )
@@ -154,7 +154,7 @@ class MaxRowsPerID(Constraint):
             return generate_nested_transformation(
                 child_transformation,
                 child_ref.parent,
-                {AddRemoveKeys: gen_tranformation_ark},
+                {AddRemoveKeys: gen_transformation_ark},
             )
 
 
@@ -254,7 +254,7 @@ class MaxGroupsPerID(Constraint):
 
         else:
 
-            def gen_tranformation_ark(parent_domain, parent_metric, target):
+            def gen_transformation_ark(parent_domain, parent_metric, target):
                 return LimitKeysPerGroupValue(
                     parent_domain,
                     parent_metric,
@@ -267,7 +267,7 @@ class MaxGroupsPerID(Constraint):
             return generate_nested_transformation(
                 child_transformation,
                 child_ref.parent,
-                {AddRemoveKeys: gen_tranformation_ark},
+                {AddRemoveKeys: gen_transformation_ark},
             )
 
 
@@ -358,7 +358,7 @@ class MaxRowsPerGroupPerID(Constraint):
                     " with the AddRowsWithID protected change."
                 )
 
-            def gen_tranformation_ark(parent_domain, parent_metric, target):
+            def gen_transformation_ark(parent_domain, parent_metric, target):
                 return LimitRowsPerKeyPerGroupValue(
                     parent_domain,
                     parent_metric,
@@ -371,5 +371,5 @@ class MaxRowsPerGroupPerID(Constraint):
             return generate_nested_transformation(
                 child_transformation,
                 child_ref.parent,
-                {AddRemoveKeys: gen_tranformation_ark},
+                {AddRemoveKeys: gen_transformation_ark},
             )

--- a/src/tmlt/analytics/query_builder.py
+++ b/src/tmlt/analytics/query_builder.py
@@ -1722,9 +1722,7 @@ class QueryBuilder:
         Args:
             constraint: The constraint to enforce.
         """
-        self._query_expr = EnforceConstraint(
-            self._query_expr, constraint, options=FrozenDict.from_dict({})
-        )
+        self._query_expr = EnforceConstraint(self._query_expr, constraint)
         return self
 
     def get_groups(self, columns: Optional[List[str]] = None) -> Query:

--- a/test/unit/test_query_expression_visitor.py
+++ b/test/unit/test_query_expression_visitor.py
@@ -155,12 +155,7 @@ class QueryExprIdentifierVisitor(QueryExprVisitor):
         ),
         (DropInfinity(PrivateSource("P"), tuple("column")), "DropInfinity"),
         (DropNullAndNan(PrivateSource("P"), tuple("column")), "DropNullAndNan"),
-        (
-            EnforceConstraint(
-                PrivateSource("P"), MaxRowsPerID(5), FrozenDict.from_dict({})
-            ),
-            "EnforceConstraint",
-        ),
+        (EnforceConstraint(PrivateSource("P"), MaxRowsPerID(5)), "EnforceConstraint"),
         (GetGroups(PrivateSource("P"), tuple("column")), "GetGroups"),
         (
             GetBounds(PrivateSource("P"), KeySet.from_dict({}), "A", "lower", "upper"),


### PR DESCRIPTION
Also fix a typo and remove tests. I don't fully understand how constraint enforcement work, but the logic that varies according to whether `update_metric=True` seems to still be there (and properly tested) in the `_enforce` method of each constraint.