### PR TITLE
Simplify assert_frame_equal_with_sort

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -229,7 +229,6 @@ def assert_frame_equal_with_sort(
     first_df: pd.DataFrame,
     second_df: pd.DataFrame,
     sort_columns: Optional[Sequence[str]] = None,
-    **kwargs: Any,
 ):
     """Asserts that the two Pandas DataFrames are equal.
 
@@ -240,7 +239,6 @@ def assert_frame_equal_with_sort(
         first_df: First dataframe to compare.
         second_df: Second dataframe to compare.
         sort_columns: Names of column to sort on. By default sorts by all columns.
-        **kwargs: Keyword arguments that will be passed to assert_frame_equal().
     """
     if sorted(first_df.columns) != sorted(second_df.columns):
         raise ValueError(
@@ -258,7 +256,7 @@ def assert_frame_equal_with_sort(
     # We explicitly pass check_dtype=False the equality check, so that identical
     # DataFrames which differ only in dtypes (like one with an int64 column and
     # the other with an Int64 column) are considered equal.
-    pd.testing.assert_frame_equal(first_df, second_df, check_dtype=False, **kwargs)
+    pd.testing.assert_frame_equal(first_df, second_df, check_dtype=False)
 
 
 def create_mock_measurement(

--- a/test/system/session/rows/test_add_max_rows.py
+++ b/test/system/session/rows/test_add_max_rows.py
@@ -634,7 +634,7 @@ class TestSession:
             f=lambda row: [{}, {}],
             new_column_types={},
             augment=True,
-            max_rows=1,
+            max_rows=2,
         )
         session.create_view(transformation_query, "flatmap_transformation", cache=False)
 
@@ -644,7 +644,7 @@ class TestSession:
             .sum("X", 0, 3, name="sum")
         )
         actual = session.evaluate(sum_query, privacy_budget)
-        assert_frame_equal_with_sort(actual.toPandas(), expected, rtol=1)
+        assert_frame_equal_with_sort(actual.toPandas(), expected)
 
     @pytest.mark.parametrize(
         "starting_budget,partition_budget",


### PR DESCRIPTION
and also fixes a *very* cursed test¹

¹ it was testing equality between two DataFrames that differed by a (deterministic) factor of 2, by using the "relative tolerance = 1" option of pandas' [assert_frame_equal](https://pandas.pydata.org/docs/dev/reference/api/pandas.testing.assert_frame_equal.html) :D

Preliminary step for https://github.com/opendp/tumult-analytics/issues/112