### PR TITLE
Replace isort with Ruff's isort rules

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -142,7 +142,6 @@ sm = SessionManager(
 sm.build()
 
 sm.black()
-sm.isort()
 sm.ruff_check()
 sm.mypy()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ default-groups = "all"
 [dependency-groups]
 ruff = ["ruff >=0.14.3,<1"]
 black = ["black >=23.3,<24"]
-isort = ["isort >=5.11,<6"]
 mypy = ["mypy >=1.14.0"]
 test = [
     "pytest",
@@ -137,10 +136,11 @@ packages = ["src/tmlt"]
 [tool.ruff.lint]
 # A list of all of Ruff's rules can be found at https://docs.astral.sh/ruff/rules/
 select = [
-    # Enable Ruff-specific lints plus Pylint, pydocstyle, pyflakes, and pycodestyle.
-    # The latter two cover many lints that we previously used pylint for, but
-    # because they are overlapping Ruff only implements them in one set of rules.
-    "RUF", "PL", "D", "F", "E", "W",
+    # Enable Ruff-specific lints plus isort, Pylint, pydocstyle, pyflakes, and
+    # pycodestyle.  The latter two cover many lints that we previously used
+    # pylint for, but because they are overlapping Ruff only implements them in
+    # one set of rules.
+    "RUF", "I", "PL", "D", "F", "E", "W",
     # Also enable a subset of flake8 rules, for similar reasons to pyflakes/pycodestyle.
     "ISC", "SLF"
 ]
@@ -185,19 +185,15 @@ ignore = [
 # those characters.
 allowed-confusables = ['α', 'ρ', '𝝆']
 
+[tool.ruff.lint.isort]
+forced-separate = ["test"]
+combine-as-imports = true
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
 [tool.black]
 force-exclude = "noxfile.py"
-
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 88
 
 [tool.mypy]
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src"

--- a/src/tmlt/analytics/__init__.py
+++ b/src/tmlt/analytics/__init__.py
@@ -82,5 +82,3 @@ from tmlt.analytics.truncation_strategy import TruncationStrategy
 
 # This version file is populated during build -- do not commit it.
 from ._version import __version__
-
-# isort: off

--- a/src/tmlt/analytics/_neighboring_relation_visitor.py
+++ b/src/tmlt/analytics/_neighboring_relation_visitor.py
@@ -12,8 +12,8 @@ from tmlt.core.domains.base import Domain
 from tmlt.core.domains.collections import DictDomain
 from tmlt.core.domains.spark_domains import SparkDataFrameDomain
 from tmlt.core.measures import ApproxDP, PureDP, RhoZCDP
-from tmlt.core.metrics import AddRemoveKeys as CoreAddRemoveKeys
 from tmlt.core.metrics import (
+    AddRemoveKeys as CoreAddRemoveKeys,
     DictMetric,
     IfGroupedBy,
     Metric,

--- a/src/tmlt/analytics/_query_expr_compiler/_base_measurement_visitor.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_base_measurement_visitor.py
@@ -69,13 +69,12 @@ from tmlt.analytics._query_expr import (
     AverageMechanism,
     CountDistinctMechanism,
     CountMechanism,
-)
-from tmlt.analytics._query_expr import DropInfinity as DropInfExpr
-from tmlt.analytics._query_expr import DropNullAndNan, EnforceConstraint
-from tmlt.analytics._query_expr import Filter as FilterExpr
-from tmlt.analytics._query_expr import FlatMap as FlatMapExpr
-from tmlt.analytics._query_expr import FlatMapByID as FlatMapByIDExpr
-from tmlt.analytics._query_expr import (
+    DropInfinity as DropInfExpr,
+    DropNullAndNan,
+    EnforceConstraint,
+    Filter as FilterExpr,
+    FlatMap as FlatMapExpr,
+    FlatMapByID as FlatMapByIDExpr,
     GetBounds,
     GetGroups,
     GroupByBoundedAverage,
@@ -85,16 +84,16 @@ from tmlt.analytics._query_expr import (
     GroupByCount,
     GroupByCountDistinct,
     GroupByQuantile,
-)
-from tmlt.analytics._query_expr import JoinPrivate as JoinPrivateExpr
-from tmlt.analytics._query_expr import JoinPublic as JoinPublicExpr
-from tmlt.analytics._query_expr import Map as MapExpr
-from tmlt.analytics._query_expr import PrivateSource as PrivateSourceExpr
-from tmlt.analytics._query_expr import QueryExpr, QueryExprVisitor
-from tmlt.analytics._query_expr import Rename as RenameExpr
-from tmlt.analytics._query_expr import ReplaceInfinity, ReplaceNullAndNan
-from tmlt.analytics._query_expr import Select as SelectExpr
-from tmlt.analytics._query_expr import (
+    JoinPrivate as JoinPrivateExpr,
+    JoinPublic as JoinPublicExpr,
+    Map as MapExpr,
+    PrivateSource as PrivateSourceExpr,
+    QueryExpr,
+    QueryExprVisitor,
+    Rename as RenameExpr,
+    ReplaceInfinity,
+    ReplaceNullAndNan,
+    Select as SelectExpr,
     StdevMechanism,
     SumMechanism,
     SuppressAggregates,

--- a/src/tmlt/analytics/_query_expr_compiler/_base_transformation_visitor.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_base_transformation_visitor.py
@@ -33,41 +33,17 @@ from tmlt.core.transformations.dictionary import (
 from tmlt.core.transformations.identity import Identity as IdentityTransformation
 from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     DropInfsValue as DropInfsValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     DropNaNsValue as DropNaNsValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     DropNullsValue as DropNullsValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     FilterValue as FilterValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     FlatMapByKeyValue as FlatMapByKeyValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     FlatMapValue as FlatMapValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     MapValue as MapValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     PublicJoinValue as PublicJoinValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     RenameValue as RenameValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     ReplaceInfsValue as ReplaceInfsValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     ReplaceNaNsValue as ReplaceNaNsValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     ReplaceNullsValue as ReplaceNullsValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     SelectValue as SelectValueTransformation,
 )
 from tmlt.core.transformations.spark_transformations.filter import (
@@ -75,42 +51,24 @@ from tmlt.core.transformations.spark_transformations.filter import (
 )
 from tmlt.core.transformations.spark_transformations.join import (
     PrivateJoin as PrivateJoinTransformation,
-)
-from tmlt.core.transformations.spark_transformations.join import (
     PrivateJoinOnKey as PrivateJoinOnKeyTransformation,
-)
-from tmlt.core.transformations.spark_transformations.join import (
     PublicJoin as PublicJoinTransformation,
-)
-from tmlt.core.transformations.spark_transformations.join import (
     TruncationStrategy as CoreTruncationStrategy,
 )
 from tmlt.core.transformations.spark_transformations.map import (
     FlatMap as FlatMapTransformation,
-)
-from tmlt.core.transformations.spark_transformations.map import GroupingFlatMap
-from tmlt.core.transformations.spark_transformations.map import Map as MapTransformation
-from tmlt.core.transformations.spark_transformations.map import (
+    GroupingFlatMap,
+    Map as MapTransformation,
     RowsToRowsTransformation,
     RowToRowsTransformation,
     RowToRowTransformation,
 )
 from tmlt.core.transformations.spark_transformations.nan import (
     DropInfs as DropInfTransformation,
-)
-from tmlt.core.transformations.spark_transformations.nan import (
     DropNaNs as DropNaNsTransformation,
-)
-from tmlt.core.transformations.spark_transformations.nan import (
     DropNulls as DropNullsTransformation,
-)
-from tmlt.core.transformations.spark_transformations.nan import (
     ReplaceInfs as ReplaceInfsTransformation,
-)
-from tmlt.core.transformations.spark_transformations.nan import (
     ReplaceNaNs as ReplaceNaNsTransformation,
-)
-from tmlt.core.transformations.spark_transformations.nan import (
     ReplaceNulls as ReplaceNullsTransformation,
 )
 from tmlt.core.transformations.spark_transformations.rename import (
@@ -122,13 +80,14 @@ from tmlt.core.transformations.spark_transformations.select import (
 
 from tmlt.analytics import AnalyticsInternalError
 from tmlt.analytics._catalog import Catalog
-from tmlt.analytics._query_expr import AnalyticsDefault
-from tmlt.analytics._query_expr import DropInfinity as DropInfExpr
-from tmlt.analytics._query_expr import DropNullAndNan, EnforceConstraint
-from tmlt.analytics._query_expr import Filter as FilterExpr
-from tmlt.analytics._query_expr import FlatMap as FlatMapExpr
-from tmlt.analytics._query_expr import FlatMapByID as FlatMapByIDExpr
 from tmlt.analytics._query_expr import (
+    AnalyticsDefault,
+    DropInfinity as DropInfExpr,
+    DropNullAndNan,
+    EnforceConstraint,
+    Filter as FilterExpr,
+    FlatMap as FlatMapExpr,
+    FlatMapByID as FlatMapByIDExpr,
     GetBounds,
     GetGroups,
     GroupByBoundedAverage,
@@ -138,15 +97,17 @@ from tmlt.analytics._query_expr import (
     GroupByCount,
     GroupByCountDistinct,
     GroupByQuantile,
+    JoinPrivate as JoinPrivateExpr,
+    JoinPublic as JoinPublicExpr,
+    Map as MapExpr,
+    QueryExpr,
+    QueryExprVisitor,
+    Rename as RenameExpr,
+    ReplaceInfinity,
+    ReplaceNullAndNan,
+    Select as SelectExpr,
+    SuppressAggregates,
 )
-from tmlt.analytics._query_expr import JoinPrivate as JoinPrivateExpr
-from tmlt.analytics._query_expr import JoinPublic as JoinPublicExpr
-from tmlt.analytics._query_expr import Map as MapExpr
-from tmlt.analytics._query_expr import QueryExpr, QueryExprVisitor
-from tmlt.analytics._query_expr import Rename as RenameExpr
-from tmlt.analytics._query_expr import ReplaceInfinity, ReplaceNullAndNan
-from tmlt.analytics._query_expr import Select as SelectExpr
-from tmlt.analytics._query_expr import SuppressAggregates
 from tmlt.analytics._query_expr_compiler._constraint_propagation import (
     propagate_flat_map,
     propagate_join_private,

--- a/src/tmlt/analytics/_schema.py
+++ b/src/tmlt/analytics/_schema.py
@@ -11,9 +11,18 @@ import datetime
 from collections.abc import Hashable, Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Iterator, List
-from typing import Mapping as MappingType
-from typing import NamedTuple, Optional, Tuple, Union, cast
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Mapping as MappingType,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from pyspark.sql.types import (
     DataType,

--- a/src/tmlt/analytics/_transformation_utils.py
+++ b/src/tmlt/analytics/_transformation_utils.py
@@ -10,26 +10,20 @@ from tmlt.core.domains.collections import DictDomain
 from tmlt.core.domains.spark_domains import SparkDataFrameDomain
 from tmlt.core.metrics import AddRemoveKeys, DictMetric, Metric
 from tmlt.core.transformations.base import Transformation
-from tmlt.core.transformations.dictionary import GetValue as GetValueTransformation
-from tmlt.core.transformations.dictionary import Subset as SubsetTransformation
 from tmlt.core.transformations.dictionary import (
+    GetValue as GetValueTransformation,
+    Subset as SubsetTransformation,
     create_copy_and_transform_value,
     create_transform_value,
 )
 from tmlt.core.transformations.identity import Identity
 from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     PersistValue as PersistValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     RenameValue as RenameValueTransformation,
-)
-from tmlt.core.transformations.spark_transformations.add_remove_keys import (
     UnpersistValue as UnpersistValueTransformation,
 )
 from tmlt.core.transformations.spark_transformations.persist import (
     Persist as PersistTransformation,
-)
-from tmlt.core.transformations.spark_transformations.persist import (
     Unpersist as UnpersistTransformation,
 )
 

--- a/src/tmlt/analytics/session.py
+++ b/src/tmlt/analytics/session.py
@@ -9,8 +9,10 @@ from warnings import warn
 
 import pandas as pd  # needed for doctests
 import sympy as sp
-from pyspark.sql import SparkSession  # needed for doctests
-from pyspark.sql import DataFrame
+from pyspark.sql import (
+    DataFrame,
+    SparkSession,  # needed for doctests
+)
 from tabulate import tabulate
 from tmlt.core.domains.collections import DictDomain
 from tmlt.core.domains.spark_domains import SparkDataFrameDomain

--- a/test/system/session/ids/test_partition.py
+++ b/test/system/session/ids/test_partition.py
@@ -7,8 +7,11 @@
 import pandas as pd
 import pytest
 import sympy as sp
-from tmlt.core.metrics import AddRemoveKeys as CoreAddRemoveKeys
-from tmlt.core.metrics import DictMetric, SymmetricDifference
+from tmlt.core.metrics import (
+    AddRemoveKeys as CoreAddRemoveKeys,
+    DictMetric,
+    SymmetricDifference,
+)
 from tmlt.core.utils.testing import assert_dataframe_equal
 
 from tmlt.analytics import (

--- a/test/unit/query_expr_compiler/test_measurement_visitor.py
+++ b/test/unit/query_expr_compiler/test_measurement_visitor.py
@@ -1,5 +1,4 @@
 """Tests for MeasurementVisitor."""
-from test.conftest import create_empty_input
 from typing import List, Union
 from unittest.mock import patch
 
@@ -43,9 +42,7 @@ from tmlt.analytics._query_expr import (
     AverageMechanism,
     CountDistinctMechanism,
     CountMechanism,
-)
-from tmlt.analytics._query_expr import DropInfinity as DropInfExpr
-from tmlt.analytics._query_expr import (
+    DropInfinity as DropInfExpr,
     DropNullAndNan,
     Filter,
     FlatMap,
@@ -62,11 +59,9 @@ from tmlt.analytics._query_expr import (
     PrivateSource,
     QueryExpr,
     Rename,
-)
-from tmlt.analytics._query_expr import ReplaceInfinity as ReplaceInfExpr
-from tmlt.analytics._query_expr import ReplaceNullAndNan
-from tmlt.analytics._query_expr import Select as SelectExpr
-from tmlt.analytics._query_expr import (
+    ReplaceInfinity as ReplaceInfExpr,
+    ReplaceNullAndNan,
+    Select as SelectExpr,
     StdevMechanism,
     SumMechanism,
     SuppressAggregates,
@@ -84,6 +79,8 @@ from tmlt.analytics._schema import (
     spark_schema_to_analytics_columns,
 )
 from tmlt.analytics._table_identifier import NamedTable
+
+from test.conftest import create_empty_input
 
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025

--- a/test/unit/query_expr_compiler/transformation_visitor/test_add_rows.py
+++ b/test/unit/query_expr_compiler/transformation_visitor/test_add_rows.py
@@ -22,8 +22,8 @@ from tmlt.core.transformations.identity import Identity as IdentityTransformatio
 
 from tmlt.analytics import KeySet, TruncationStrategy
 from tmlt.analytics._catalog import Catalog
-from tmlt.analytics._query_expr import DropInfinity as DropInfExpr
 from tmlt.analytics._query_expr import (
+    DropInfinity as DropInfExpr,
     DropNullAndNan,
     Filter,
     FlatMap,

--- a/test/unit/test_neighboring_relations.py
+++ b/test/unit/test_neighboring_relations.py
@@ -13,8 +13,8 @@ from pyspark.sql import DataFrame
 from tmlt.core.domains.collections import DictDomain
 from tmlt.core.domains.spark_domains import SparkDataFrameDomain
 from tmlt.core.measures import PureDP, RhoZCDP
-from tmlt.core.metrics import AddRemoveKeys as CoreAddRemoveKeys
 from tmlt.core.metrics import (
+    AddRemoveKeys as CoreAddRemoveKeys,
     DictMetric,
     IfGroupedBy,
     RootSumOfSquared,

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -36,8 +36,8 @@ from tmlt.core.measurements.interactive_measurements import (
     SequentialQueryable,
 )
 from tmlt.core.measures import ApproxDP, Measure, PureDP, RhoZCDP
-from tmlt.core.metrics import AddRemoveKeys as CoreAddRemoveKeys
 from tmlt.core.metrics import (
+    AddRemoveKeys as CoreAddRemoveKeys,
     DictMetric,
     IfGroupedBy,
     Metric,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform != 'darwin'",
@@ -537,15 +537,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
-]
-
-[[package]]
-name = "isort"
-version = "5.13.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303, upload-time = "2023-12-13T20:37:26.124Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310, upload-time = "2023-12-13T20:37:23.244Z" },
 ]
 
 [[package]]
@@ -1941,9 +1932,6 @@ docs-examples = [
     { name = "matplotlib" },
     { name = "seaborn" },
 ]
-isort = [
-    { name = "isort" },
-]
 mypy = [
     { name = "mypy" },
 ]
@@ -1998,7 +1986,6 @@ docs-examples = [
     { name = "matplotlib", specifier = ">=3.1.0,<4" },
     { name = "seaborn", specifier = ">=0.13.0,<0.14" },
 ]
-isort = [{ name = "isort", specifier = ">=5.11,<6" }]
 mypy = [{ name = "mypy", specifier = ">=1.14.0" }]
 ruff = [{ name = "ruff", specifier = ">=0.14.3,<1" }]
 scripting = [


### PR DESCRIPTION
The majority of the diff here comes from enabling the `combine-as-imports` option, which IMO makes some of the big blocks of `as` imports a lot easier to parse. Other than that and forcing test imports into their own sections, this uses the default settings.