### PR TITLE
Removes Duplicate Line

### DIFF
--- a/src/tmlt/analytics/_query_expr_compiler/_base_measurement_visitor.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_base_measurement_visitor.py
@@ -1565,9 +1565,6 @@ class BaseMeasurementVisitor(QueryExprVisitor):
                 self.adjusted_budget
             )
 
-        # Peek at the schema, to see if there are errors there
-        expr.schema(self.catalog)
-
         child_transformation, child_ref = self._truncate_table(
             *self._visit_child_transformation(expr.child, NoiseMechanism.GEOMETRIC),
             grouping_columns=groupby_cols,


### PR DESCRIPTION
This removes an unnecessary line in the `visit_get_bounds` method.