### PR TITLE
Switch to Ruff for code formatting

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -141,7 +141,7 @@ sm = SessionManager(
 
 sm.build()
 
-sm.black()
+sm.ruff_format()
 sm.ruff_check()
 sm.mypy()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ default-groups = "all"
 
 [dependency-groups]
 ruff = ["ruff >=0.14.3,<1"]
-black = ["black >=23.3,<24"]
 mypy = ["mypy >=1.14.0"]
 test = [
     "pytest",
@@ -191,9 +190,6 @@ combine-as-imports = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
-
-[tool.black]
-force-exclude = "noxfile.py"
 
 [tool.mypy]
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src"

--- a/src/tmlt/analytics/_neighboring_relation.py
+++ b/src/tmlt/analytics/_neighboring_relation.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
-
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
@@ -340,8 +339,9 @@ class Conjunction(NeighboringRelation):
             if set(covered_tables) & set(relation_table_names):
                 raise ValueError(
                     f"""It appears a table is used more than once in the relation.
-                    Duplicate table(s): {set(covered_tables)&
-                    set(relation_table_names)}"""
+                    Duplicate table(s): {
+                        set(covered_tables) & set(relation_table_names)
+                    }"""
                 )
             covered_tables.extend(relation_table_names)
         # the sets don't match, meaning a table was left out of either the relation
@@ -350,8 +350,9 @@ class Conjunction(NeighboringRelation):
             raise ValueError(
                 f"""It appears that the list of input tables doesn't match the list of
                 tables used in the relation.
-                Tables that appear in only one list: {set(dfs.keys())^
-                set(covered_tables)}
+                Tables that appear in only one list: {
+                    set(dfs.keys()) ^ set(covered_tables)
+                }
                 """
             )
         return True

--- a/src/tmlt/analytics/_query_expr_compiler/_base_measurement_visitor.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_base_measurement_visitor.py
@@ -1,4 +1,5 @@
 """Defines a base class for building measurement visitors."""
+
 import math
 import warnings
 from abc import abstractmethod
@@ -126,7 +127,7 @@ def _get_core_mechanism(
         GroupByBoundedVariance,
         GroupByCount,
         GroupByCountDistinct,
-    ]
+    ],
 ) -> NoiseMechanism:
     if query.core_mechanism is None:
         raise AnalyticsInternalError(
@@ -143,7 +144,7 @@ def _get_query_bounds(
         GroupByBoundedSum,
         GroupByBoundedVariance,
         GroupByQuantile,
-    ]
+    ],
 ) -> Tuple[ExactNumber, ExactNumber]:
     """Returns lower and upper clamping bounds of a query as :class:`~.ExactNumbers`."""
     if query.high == query.low:

--- a/src/tmlt/analytics/_query_expr_compiler/_rewrite_rules.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_rewrite_rules.py
@@ -56,7 +56,7 @@ class CompilationInfo:
 
 
 def depth_first(
-    func: Callable[[QueryExpr], QueryExpr]
+    func: Callable[[QueryExpr], QueryExpr],
 ) -> Callable[[QueryExpr], QueryExpr]:
     """Recursively applies the given method to a QueryExpr, depth-first."""
 

--- a/src/tmlt/analytics/binning_spec.py
+++ b/src/tmlt/analytics/binning_spec.py
@@ -80,7 +80,8 @@ def _edges_as_str(bin_edges: Tuple[BinT]) -> Tuple[str, ...]:
         else:
             timespec = "minutes"
         return tuple(
-            e.isoformat(sep=" ", timespec=timespec) for e in bin_edges  # type: ignore
+            e.isoformat(sep=" ", timespec=timespec)  # type: ignore
+            for e in bin_edges
         )
     elif isinstance(bin_edges[0], str):
         # Use repr for strings so that they get quoted.
@@ -97,22 +98,22 @@ def _default_bin_names(
     if right:
         if include_edges:
             return [f"[{bin_edge_strs[0]}, {bin_edge_strs[1]}]"] + [
-                f"({bin_edge_strs[i]}, {bin_edge_strs[i+1]}]"
+                f"({bin_edge_strs[i]}, {bin_edge_strs[i + 1]}]"
                 for i in range(1, len(bin_edges) - 1)
             ]
         else:
             return [
-                f"({bin_edge_strs[i]}, {bin_edge_strs[i+1]}]"
+                f"({bin_edge_strs[i]}, {bin_edge_strs[i + 1]}]"
                 for i in range(len(bin_edges) - 1)
             ]
     elif include_edges:
         return [
-            f"[{bin_edge_strs[i]}, {bin_edge_strs[i+1]})"
+            f"[{bin_edge_strs[i]}, {bin_edge_strs[i + 1]})"
             for i in range(len(bin_edges) - 2)
         ] + [f"[{bin_edge_strs[-2]}, {bin_edge_strs[-1]}]"]
     else:
         return [
-            f"[{bin_edge_strs[i]}, {bin_edge_strs[i+1]})"
+            f"[{bin_edge_strs[i]}, {bin_edge_strs[i + 1]})"
             for i in range(len(bin_edges) - 1)
         ]
 

--- a/src/tmlt/analytics/constraints/_base.py
+++ b/src/tmlt/analytics/constraints/_base.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
-
 from abc import ABC, abstractmethod
 from typing import Tuple
 

--- a/src/tmlt/analytics/keyset/_keyset.py
+++ b/src/tmlt/analytics/keyset/_keyset.py
@@ -204,12 +204,10 @@ class KeySet:
         return KeySetPlan(Detect(frozenset(columns)), columns=columns)
 
     @overload
-    def __mul__(self, other: KeySet) -> KeySet:
-        ...
+    def __mul__(self, other: KeySet) -> KeySet: ...
 
     @overload
-    def __mul__(self, other: KeySetPlan) -> KeySetPlan:
-        ...
+    def __mul__(self, other: KeySetPlan) -> KeySetPlan: ...
 
     def __mul__(self, other):
         r"""The Cartesian product of the two KeySet factors.
@@ -315,12 +313,10 @@ class KeySet:
         )
 
     @overload
-    def join(self, other: KeySet) -> KeySet:
-        ...
+    def join(self, other: KeySet) -> KeySet: ...
 
     @overload
-    def join(self, other: KeySetPlan) -> KeySetPlan:
-        ...
+    def join(self, other: KeySetPlan) -> KeySetPlan: ...
 
     def join(self, other):
         r"""The inner natural join of two KeySet objects.
@@ -401,12 +397,10 @@ class KeySet:
         return KeySet(Filter(self._op_tree, condition), columns=self.columns())
 
     @overload
-    def union(self, other: KeySet) -> KeySet:
-        ...
+    def union(self, other: KeySet) -> KeySet: ...
 
     @overload
-    def union(self, other: KeySetPlan) -> KeySetPlan:
-        ...
+    def union(self, other: KeySetPlan) -> KeySetPlan: ...
 
     def union(self, other):
         """Compute the union of this KeySet with another KeySet.

--- a/src/tmlt/analytics/keyset/_ops/_base.py
+++ b/src/tmlt/analytics/keyset/_ops/_base.py
@@ -53,19 +53,16 @@ class KeySetOp(ABC):
         """Determine whether this plan has any parts requiring partition selection."""
 
     @overload
-    def size(self, fast: Literal[True]) -> Optional[int]:
-        ...
+    def size(self, fast: Literal[True]) -> Optional[int]: ...
 
     @overload
-    def size(self, fast: Literal[False]) -> int:
-        ...
+    def size(self, fast: Literal[False]) -> int: ...
 
     # Needed to make mypy happy, as it won't automatically combine the above
     # overloads to understand that fast is a bool.
     #   https://github.com/python/mypy/issues/10194
     @overload
-    def size(self, fast: bool) -> Optional[int]:
-        ...
+    def size(self, fast: bool) -> Optional[int]: ...
 
     @abstractmethod
     def size(self, fast):

--- a/src/tmlt/analytics/keyset/_ops/_cross_join.py
+++ b/src/tmlt/analytics/keyset/_ops/_cross_join.py
@@ -108,16 +108,13 @@ class CrossJoin(KeySetOp):
         return any(f.is_plan() for f in self.factors)
 
     @overload
-    def size(self, fast: Literal[True]) -> Optional[int]:
-        ...
+    def size(self, fast: Literal[True]) -> Optional[int]: ...
 
     @overload
-    def size(self, fast: Literal[False]) -> int:
-        ...
+    def size(self, fast: Literal[False]) -> int: ...
 
     @overload
-    def size(self, fast: bool) -> Optional[int]:
-        ...
+    def size(self, fast: bool) -> Optional[int]: ...
 
     def size(self, fast):
         """Determine the size of the KeySet resulting from this operation."""

--- a/src/tmlt/analytics/keyset/_ops/_detect.py
+++ b/src/tmlt/analytics/keyset/_ops/_detect.py
@@ -66,16 +66,13 @@ class Detect(KeySetOp):
         return True
 
     @overload
-    def size(self, fast: Literal[True]) -> Optional[int]:
-        ...
+    def size(self, fast: Literal[True]) -> Optional[int]: ...
 
     @overload
-    def size(self, fast: Literal[False]) -> int:
-        ...
+    def size(self, fast: Literal[False]) -> int: ...
 
     @overload
-    def size(self, fast: bool) -> Optional[int]:
-        ...
+    def size(self, fast: bool) -> Optional[int]: ...
 
     def size(self, fast):
         """Determine the size of the KeySet resulting from this operation.

--- a/src/tmlt/analytics/keyset/_ops/_filter.py
+++ b/src/tmlt/analytics/keyset/_ops/_filter.py
@@ -61,16 +61,13 @@ class Filter(KeySetOp):
         return self.child.is_plan()
 
     @overload
-    def size(self, fast: Literal[True]) -> Optional[int]:
-        ...
+    def size(self, fast: Literal[True]) -> Optional[int]: ...
 
     @overload
-    def size(self, fast: Literal[False]) -> int:
-        ...
+    def size(self, fast: Literal[False]) -> int: ...
 
     @overload
-    def size(self, fast: bool) -> Optional[int]:
-        ...
+    def size(self, fast: bool) -> Optional[int]: ...
 
     def size(self, fast):
         """Determine the size of the KeySet resulting from this operation."""

--- a/src/tmlt/analytics/keyset/_ops/_from_dataframe.py
+++ b/src/tmlt/analytics/keyset/_ops/_from_dataframe.py
@@ -52,16 +52,13 @@ class FromSparkDataFrame(KeySetOp):
         return False
 
     @overload
-    def size(self, fast: Literal[True]) -> Optional[int]:
-        ...
+    def size(self, fast: Literal[True]) -> Optional[int]: ...
 
     @overload
-    def size(self, fast: Literal[False]) -> int:
-        ...
+    def size(self, fast: Literal[False]) -> int: ...
 
     @overload
-    def size(self, fast: bool) -> Optional[int]:
-        ...
+    def size(self, fast: bool) -> Optional[int]: ...
 
     def size(self, fast):
         """Determine the size of the KeySet resulting from this operation."""

--- a/src/tmlt/analytics/keyset/_ops/_from_tuples.py
+++ b/src/tmlt/analytics/keyset/_ops/_from_tuples.py
@@ -74,16 +74,13 @@ class FromTuples(KeySetOp):
         return False
 
     @overload
-    def size(self, fast: Literal[True]) -> Optional[int]:
-        ...
+    def size(self, fast: Literal[True]) -> Optional[int]: ...
 
     @overload
-    def size(self, fast: Literal[False]) -> int:
-        ...
+    def size(self, fast: Literal[False]) -> int: ...
 
     @overload
-    def size(self, fast: bool) -> Optional[int]:
-        ...
+    def size(self, fast: bool) -> Optional[int]: ...
 
     def size(self, fast):
         """Determine the size of the KeySet resulting from this operation."""

--- a/src/tmlt/analytics/keyset/_ops/_join.py
+++ b/src/tmlt/analytics/keyset/_ops/_join.py
@@ -95,16 +95,13 @@ class Join(KeySetOp):
         return self.left.is_plan() or self.right.is_plan()
 
     @overload
-    def size(self, fast: Literal[True]) -> Optional[int]:
-        ...
+    def size(self, fast: Literal[True]) -> Optional[int]: ...
 
     @overload
-    def size(self, fast: Literal[False]) -> int:
-        ...
+    def size(self, fast: Literal[False]) -> int: ...
 
     @overload
-    def size(self, fast: bool) -> Optional[int]:
-        ...
+    def size(self, fast: bool) -> Optional[int]: ...
 
     def size(self, fast):
         """Determine the size of the KeySet resulting from this operation."""

--- a/src/tmlt/analytics/keyset/_ops/_project.py
+++ b/src/tmlt/analytics/keyset/_ops/_project.py
@@ -80,16 +80,13 @@ class Project(KeySetOp):
         return self.child.is_plan()
 
     @overload
-    def size(self, fast: Literal[True]) -> Optional[int]:
-        ...
+    def size(self, fast: Literal[True]) -> Optional[int]: ...
 
     @overload
-    def size(self, fast: Literal[False]) -> int:
-        ...
+    def size(self, fast: Literal[False]) -> int: ...
 
     @overload
-    def size(self, fast: bool) -> Optional[int]:
-        ...
+    def size(self, fast: bool) -> Optional[int]: ...
 
     def size(self, fast):
         """Determine the size of the KeySet resulting from this operation."""

--- a/src/tmlt/analytics/keyset/_ops/_rules.py
+++ b/src/tmlt/analytics/keyset/_ops/_rules.py
@@ -69,7 +69,7 @@ def depth_first(func: Callable[[KeySetOp], KeySetOp]) -> Callable[[KeySetOp], Ke
 
 
 def breadth_first(
-    func: Callable[[KeySetOp], KeySetOp]
+    func: Callable[[KeySetOp], KeySetOp],
 ) -> Callable[[KeySetOp], KeySetOp]:
     """Recursively apply the given method to an op-tree, breadth-first.
 

--- a/src/tmlt/analytics/keyset/_ops/_subtract.py
+++ b/src/tmlt/analytics/keyset/_ops/_subtract.py
@@ -74,16 +74,13 @@ class Subtract(KeySetOp):
         return self.left.is_plan()
 
     @overload
-    def size(self, fast: Literal[True]) -> Optional[int]:
-        ...
+    def size(self, fast: Literal[True]) -> Optional[int]: ...
 
     @overload
-    def size(self, fast: Literal[False]) -> int:
-        ...
+    def size(self, fast: Literal[False]) -> int: ...
 
     @overload
-    def size(self, fast: bool) -> Optional[int]:
-        ...
+    def size(self, fast: bool) -> Optional[int]: ...
 
     def size(self, fast):
         """Determine the size of the KeySet resulting from this operation.

--- a/src/tmlt/analytics/keyset/_ops/_union.py
+++ b/src/tmlt/analytics/keyset/_ops/_union.py
@@ -96,16 +96,13 @@ class Union(KeySetOp):
         return self.left.is_plan() or self.right.is_plan()
 
     @overload
-    def size(self, fast: Literal[True]) -> Optional[int]:
-        ...
+    def size(self, fast: Literal[True]) -> Optional[int]: ...
 
     @overload
-    def size(self, fast: Literal[False]) -> int:
-        ...
+    def size(self, fast: Literal[False]) -> int: ...
 
     @overload
-    def size(self, fast: bool) -> Optional[int]:
-        ...
+    def size(self, fast: bool) -> Optional[int]: ...
 
     def size(self, fast):
         """Determine the size of the KeySet resulting from this operation."""

--- a/src/tmlt/analytics/query_builder.py
+++ b/src/tmlt/analytics/query_builder.py
@@ -151,8 +151,7 @@ class Query:
 
 class _QueryProtocol(Protocol):
     @property
-    def _query_expr(self) -> QueryExpr:
-        ...
+    def _query_expr(self) -> QueryExpr: ...
 
 
 class _PostProcessSuppressMixin:

--- a/src/tmlt/analytics/session.py
+++ b/src/tmlt/analytics/session.py
@@ -131,9 +131,9 @@ def _generate_neighboring_relation(sources: Dict[str, PrivateDataFrame]) -> Conj
         elif isinstance(protected_change, AddRowsWithID):
             if protected_ids_dict.get(protected_change.id_space) is None:
                 protected_ids_dict[protected_change.id_space] = {}
-            protected_ids_dict[protected_change.id_space][
-                name
-            ] = protected_change.id_column
+            protected_ids_dict[protected_change.id_space][name] = (
+                protected_change.id_column
+            )
         else:
             raise ValueError(
                 f"Unsupported ProtectedChange type: {type(protected_change)}"
@@ -668,9 +668,9 @@ class Session:
                     table_desc = f"Table '{name}':\n"
                     table_desc += table_schema
 
-                    constraints: Optional[
-                        List[Constraint]
-                    ] = self._table_constraints.get(NamedTable(name))
+                    constraints: Optional[List[Constraint]] = (
+                        self._table_constraints.get(NamedTable(name))
+                    )
                     if not constraints:
                         table_desc = (
                             f"Table '{name}' (no constraints):\n" + table_schema

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -349,13 +349,11 @@ def assert_approx_equal_budgets(
 
 
 @overload
-def create_empty_input(domain: DictDomain) -> Dict:
-    ...
+def create_empty_input(domain: DictDomain) -> Dict: ...
 
 
 @overload
-def create_empty_input(domain: SparkDataFrameDomain) -> DataFrame:
-    ...
+def create_empty_input(domain: SparkDataFrameDomain) -> DataFrame: ...
 
 
 def create_empty_input(domain):

--- a/test/system/session/conftest.py
+++ b/test/system/session/conftest.py
@@ -27,13 +27,13 @@ def session(_session_data, request):
     up this way allows parametrizing tests to run with Sessions that use
     multiple privacy definitions without duplicating all of the test logic.
     """
-    assert hasattr(
-        request, "param"
-    ), "The session fixture requires a parameter indicating its budget"
+    assert hasattr(request, "param"), (
+        "The session fixture requires a parameter indicating its budget"
+    )
     budget = request.param
-    assert isinstance(
-        budget, PrivacyBudget
-    ), "The session fixture parameter must be a PrivacyBudget"
+    assert isinstance(budget, PrivacyBudget), (
+        "The session fixture parameter must be a PrivacyBudget"
+    )
 
     sess = (
         Session.Builder()

--- a/test/system/session/ids/test_partition.py
+++ b/test/system/session/ids/test_partition.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
-
 import pandas as pd
 import pytest
 import sympy as sp

--- a/test/system/session/mixed/test_mixed_session.py
+++ b/test/system/session/mixed/test_mixed_session.py
@@ -7,7 +7,6 @@ functions properly when used with a mixture of IDs and non-IDs protected changes
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
-
 import pytest
 
 from tmlt.analytics import (

--- a/test/unit/base_builder/test_mixins.py
+++ b/test/unit/base_builder/test_mixins.py
@@ -145,7 +145,9 @@ def test_dataframes_rejects_wrong_types(spark):
         builder.with_private_dataframe(1, df, AddMaxRows(1))  # type: ignore
     with pytest.raises(TypeCheckError):
         builder.with_private_dataframe(
-            "source_id", "not a dataframe", AddMaxRows(1)  # type: ignore
+            "source_id",
+            "not a dataframe",  # type: ignore
+            AddMaxRows(1),
         )
     with pytest.raises(TypeCheckError):
         # wrong type for ProtectedChange

--- a/test/unit/keysets/test_from_dict.py
+++ b/test/unit/keysets/test_from_dict.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
-
 import datetime
 from typing import Any, ContextManager, Iterable, Mapping, Optional, Union
 

--- a/test/unit/keysets/test_keyset.py
+++ b/test/unit/keysets/test_keyset.py
@@ -110,7 +110,7 @@ def test_from_dict_empty_list(
             List[Optional[int]],
             List[Optional[datetime.date]],
         ],
-    ]
+    ],
 ) -> None:
     """Test that calls like ``KeySet.from_dict({'A': []})`` raise a friendly error."""
     with pytest.raises(

--- a/test/unit/keysets/test_product_keyset.py
+++ b/test/unit/keysets/test_product_keyset.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
-
 import itertools
 from functools import reduce
 from typing import Dict, List, Sequence, Tuple

--- a/test/unit/keysets/test_subtract.py
+++ b/test/unit/keysets/test_subtract.py
@@ -193,8 +193,7 @@ def test_valid_plan(
         right=KeySet.from_tuples([(1,)], columns=["B"]),
         expectation=pytest.raises(
             ValueError,
-            match="right hand side has columns that do not exist in the left hand "
-            "side",
+            match="right hand side has columns that do not exist in the left hand side",
         ),
     ),
     Case("non_overlapping_columns")(
@@ -202,8 +201,7 @@ def test_valid_plan(
         right=KeySet.from_tuples([(2, 3)], columns=["B", "C"]),
         expectation=pytest.raises(
             ValueError,
-            match="right hand side has columns that do not exist in the left hand "
-            "side",
+            match="right hand side has columns that do not exist in the left hand side",
         ),
     ),
     Case("subtract_plan")(

--- a/test/unit/query_expr_compiler/test_measurement_visitor.py
+++ b/test/unit/query_expr_compiler/test_measurement_visitor.py
@@ -1,4 +1,5 @@
 """Tests for MeasurementVisitor."""
+
 from typing import List, Union
 from unittest.mock import patch
 

--- a/test/unit/query_expr_compiler/test_rewrite_rules.py
+++ b/test/unit/query_expr_compiler/test_rewrite_rules.py
@@ -1,4 +1,5 @@
 """Tests for rewrite rules."""
+
 from dataclasses import dataclass, replace
 from typing import Any, Union
 

--- a/test/unit/query_expr_compiler/transformation_visitor/test_constraints.py
+++ b/test/unit/query_expr_compiler/transformation_visitor/test_constraints.py
@@ -54,9 +54,9 @@ class TestConstraints(TestTransformationVisitor):
 
         # Check that each ID doesn't appear more times than the constraint bound.
         rows_per_id = result_df.groupby("id")["id"].count()
-        assert all(
-            rows_per_id <= constraint_max
-        ), f"MaxRowsPerID constraint violated, counts were:\n{rows_per_id}"
+        assert all(rows_per_id <= constraint_max), (
+            f"MaxRowsPerID constraint violated, counts were:\n{rows_per_id}"
+        )
 
         self._test_is_subset(input_df, result_df)
 
@@ -77,9 +77,9 @@ class TestConstraints(TestTransformationVisitor):
         # Check that each no ID has more groups associated with it than the
         # truncation bound.
         groups_per_id = result_df.groupby("id").nunique()[grouping_col]
-        assert all(
-            groups_per_id <= constraint_max
-        ), f"MaxGroupsPerID constraint violated, counts were:\n{groups_per_id}"
+        assert all(groups_per_id <= constraint_max), (
+            f"MaxGroupsPerID constraint violated, counts were:\n{groups_per_id}"
+        )
 
         self._test_is_subset(input_df, result_df)
 
@@ -100,10 +100,9 @@ class TestConstraints(TestTransformationVisitor):
         # Check that each (ID, grouping_column) pair doesn't appear more
         # times than the constraint bound.
         rows_per_group_per_id = result_df.value_counts(["id", grouping_col])
-        assert all(
-            rows_per_group_per_id <= constraint_max
-        ), "MaxRowsPerGroupPerID constraint violated, counts were:\n" + str(
-            rows_per_group_per_id
+        assert all(rows_per_group_per_id <= constraint_max), (
+            "MaxRowsPerGroupPerID constraint violated, counts were:\n"
+            + str(rows_per_group_per_id)
         )
 
         self._test_is_subset(input_df, result_df)

--- a/test/unit/test_catalog.py
+++ b/test/unit/test_catalog.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
-
 from typing import Optional
 
 import pytest

--- a/test/unit/test_cleanup.py
+++ b/test/unit/test_cleanup.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
-
 from unittest.mock import patch
 
 from tmlt.analytics.utils import cleanup, remove_all_temp_tables

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -122,9 +122,9 @@ def test_config_feature_flag_raise_if_disabled_snippet():
             ff.raise_if_disabled()
         error_message = str(exc_info.value)
         enable_snippet_idx = error_message.find("from tmlt.analytics")
-        assert (
-            enable_snippet_idx != -1
-        ), "No snippet to enable flag found in exception message"
+        assert enable_snippet_idx != -1, (
+            "No snippet to enable flag found in exception message"
+        )
         enable_snippet = error_message[enable_snippet_idx:]
         with patch("tmlt.analytics.config.config", cfg):
             exec(enable_snippet, {}, {})

--- a/test/unit/test_query_builder.py
+++ b/test/unit/test_query_builder.py
@@ -664,7 +664,7 @@ def test_histogram_options():
 def test_replace_null_and_nan(
     replace_with: Optional[
         Mapping[str, Union[int, float, str, datetime.date, datetime.datetime]]
-    ]
+    ],
 ) -> None:
     """QueryBuilder.replace_null_and_nan works as expected."""
     query = root_builder().replace_null_and_nan(replace_with).count()
@@ -700,7 +700,7 @@ def test_replace_null_and_nan(
     ],
 )
 def test_replace_infinity(
-    replace_with: Optional[Dict[str, Tuple[float, float]]]
+    replace_with: Optional[Dict[str, Tuple[float, float]]],
 ) -> None:
     """QueryBuilder.replace_infinity works as expected."""
     query = root_builder().replace_infinity(replace_with).count()
@@ -846,9 +846,7 @@ class TestAggregations:
         return KeySet.from_dataframe(
             # This conditional works around an odd behavior in Spark where
             # converting an empty pandas dataframe with no columns will fail.
-            spark.createDataFrame(df)
-            if not df.empty
-            else spark.createDataFrame([], "")
+            spark.createDataFrame(df) if not df.empty else spark.createDataFrame([], "")
         )
 
     def assert_root_expr(self, root_expr: QueryExpr):

--- a/test/unit/test_query_expr_compiler.py
+++ b/test/unit/test_query_expr_compiler.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
-
 import datetime
 from typing import Dict, Union
 

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -93,7 +93,7 @@ from tmlt.analytics.config import config
 
 
 def _privacy_budget_to_exact_number(
-    budget: Union[PureDPBudget, RhoZCDPBudget]
+    budget: Union[PureDPBudget, RhoZCDPBudget],
 ) -> ExactNumber:
     """Turn a privacy budget into an Exact Number."""
     if isinstance(budget, (PureDPBudget, RhoZCDPBudget)):
@@ -278,11 +278,14 @@ class TestSession:
         from_dataframe_args: Dict,
     ):
         """Tests that :func:`Session.from_dataframe` works with a grouping column."""
-        with patch(
-            "tmlt.analytics.session.SequentialComposition", autospec=True
-        ) as mock_composition_init, patch.object(
-            Session, "__init__", autospec=True, return_value=None
-        ) as mock_session_init:
+        with (
+            patch(
+                "tmlt.analytics.session.SequentialComposition", autospec=True
+            ) as mock_composition_init,
+            patch.object(
+                Session, "__init__", autospec=True, return_value=None
+            ) as mock_session_init,
+        ):
             mock_composition_init.return_value = Mock(
                 spec_set=SequentialComposition,
                 return_value=Mock(spec_set=SequentialComposition),
@@ -349,11 +352,14 @@ class TestSession:
 
         AddRemoveKeys doesn't create a DictMetric because it's special.
         """
-        with patch(
-            "tmlt.analytics.session.SequentialComposition", autospec=True
-        ) as mock_composition_init, patch.object(
-            Session, "__init__", autospec=True, return_value=None
-        ) as mock_session_init:
+        with (
+            patch(
+                "tmlt.analytics.session.SequentialComposition", autospec=True
+            ) as mock_composition_init,
+            patch.object(
+                Session, "__init__", autospec=True, return_value=None
+            ) as mock_session_init,
+        ):
             mock_composition_init.return_value = Mock(
                 spec_set=SequentialComposition,
                 return_value=Mock(spec_set=SequentialComposition),
@@ -581,11 +587,12 @@ class TestSession:
         """Confirm that using an approxdp query on a puredp accountant raises an
         error.
         """
-        with patch.object(
-            QueryExprCompiler, "__call__", autospec=True
-        ) as mock_compiler, patch(
-            "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
-        ) as mock_accountant:
+        with (
+            patch.object(QueryExprCompiler, "__call__", autospec=True) as mock_compiler,
+            patch(
+                "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
+            ) as mock_accountant,
+        ):
             self._setup_accountant_and_compiler(
                 spark, d_in, mock_accountant, mock_compiler
             )
@@ -607,11 +614,12 @@ class TestSession:
     @pytest.mark.parametrize("d_in", [(sp.Integer(1)), (sp.sqrt(sp.Integer(2)))])
     def test_evaluate_with_zero_budget(self, spark, d_in):
         """Confirm that calling evaluate with a 'budget' of 0 fails."""
-        with patch.object(
-            QueryExprCompiler, "__call__", autospec=True
-        ) as mock_compiler, patch(
-            "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
-        ) as mock_accountant:
+        with (
+            patch.object(QueryExprCompiler, "__call__", autospec=True) as mock_compiler,
+            patch(
+                "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
+            ) as mock_accountant,
+        ):
             self._setup_accountant_and_compiler(
                 spark, d_in, mock_accountant, mock_compiler
             )
@@ -653,11 +661,12 @@ class TestSession:
     @pytest.mark.parametrize("d_in", [(sp.Integer(1)), (sp.sqrt(sp.Integer(2)))])
     def test_evaluate_zcdp_session_puredp_query(self, spark, d_in):
         """Confirm that using a puredp query on a zcdp accountant raises an error."""
-        with patch.object(
-            QueryExprCompiler, "__call__", autospec=True
-        ) as mock_compiler, patch(
-            "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
-        ) as mock_accountant:
+        with (
+            patch.object(QueryExprCompiler, "__call__", autospec=True) as mock_compiler,
+            patch(
+                "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
+            ) as mock_accountant,
+        ):
             self._setup_accountant_and_compiler(
                 spark, d_in, mock_accountant, mock_compiler
             )
@@ -681,11 +690,12 @@ class TestSession:
     @pytest.mark.parametrize("d_in", [(sp.Integer(1)), (sp.sqrt(sp.Integer(2)))])
     def test_evaluate_puredp_session_zcdp_query(self, spark, d_in):
         """Confirm that using a zcdp query on a puredp accountant raises an error."""
-        with patch.object(
-            QueryExprCompiler, "__call__", autospec=True
-        ) as mock_compiler, patch(
-            "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
-        ) as mock_accountant:
+        with (
+            patch.object(QueryExprCompiler, "__call__", autospec=True) as mock_compiler,
+            patch(
+                "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
+            ) as mock_accountant,
+        ):
             self._setup_accountant_and_compiler(
                 spark, d_in, mock_accountant, mock_compiler
             )
@@ -1099,9 +1109,12 @@ class TestSession:
 
     def test_describe(self, spark):
         """Test that :func:`_describe` works correctly."""
-        with patch("builtins.print") as mock_print, patch(
-            "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
-        ) as mock_accountant:
+        with (
+            patch("builtins.print") as mock_print,
+            patch(
+                "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
+            ) as mock_accountant,
+        ):
             self._setup_accountant(mock_accountant, privacy_budget=ExactNumber(10))
             mock_accountant.state = PrivacyAccountantState.ACTIVE
 
@@ -1167,9 +1180,12 @@ Public table 'public1':\n"""
 
     def test_describe_with_constraints(self, spark):
         """Test :func:`_describe` with a table with constraints."""
-        with patch("builtins.print") as mock_print, patch(
-            "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
-        ) as mock_accountant:
+        with (
+            patch("builtins.print") as mock_print,
+            patch(
+                "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
+            ) as mock_accountant,
+        ):
             self._setup_accountant(mock_accountant, privacy_budget=ExactNumber(10))
             mock_accountant.state = PrivacyAccountantState.ACTIVE
 
@@ -1239,9 +1255,12 @@ Public table 'public1':\n"""
 
     def test_describe_with_id_column(self, spark):
         """Test :func:`_describe` with a table with an ID column."""
-        with patch("builtins.print") as mock_print, patch(
-            "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
-        ) as mock_accountant:
+        with (
+            patch("builtins.print") as mock_print,
+            patch(
+                "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
+            ) as mock_accountant,
+        ):
             self._setup_accountant_with_id(
                 mock_accountant, privacy_budget=ExactNumber(10)
             )
@@ -1474,9 +1493,12 @@ Public table 'public1':\n"""
         self, constraints: List[Constraint], expected_output: str
     ):
         """Test :func:`_describe` with a table with constraints."""
-        with patch("builtins.print") as mock_print, patch(
-            "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
-        ) as mock_accountant:
+        with (
+            patch("builtins.print") as mock_print,
+            patch(
+                "tmlt.core.measurements.interactive_measurements.PrivacyAccountant"
+            ) as mock_accountant,
+        ):
             self._setup_accountant_with_id(
                 mock_accountant, privacy_budget=ExactNumber(10)
             )
@@ -2537,12 +2559,12 @@ def test_automatic_partitions_with_ids(
         (
             ApproxDPBudget(0, 0.1),
             "Automatic partition selection requires a positive "
-            f"epsilon. The budget provided was {ApproxDPBudget(0,.1)}.",
+            f"epsilon. The budget provided was {ApproxDPBudget(0, 0.1)}.",
         ),
         (
             ApproxDPBudget(1, 0),
             "Automatic partition selection requires a positive "
-            f"delta. The budget provided was {ApproxDPBudget(1,0)}.",
+            f"delta. The budget provided was {ApproxDPBudget(1, 0)}.",
         ),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -93,36 +93,6 @@ wheels = [
 ]
 
 [[package]]
-name = "black"
-version = "23.12.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/f4/a57cde4b60da0e249073009f4a9087e9e0a955deae78d3c2a493208d0c5c/black-23.12.1.tar.gz", hash = "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5", size = 620809, upload-time = "2023-12-22T23:06:17.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/58/677da52d845b59505a8a787ff22eff9cfd9046b5789aa2bd387b236db5c5/black-23.12.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0aaf6041986767a5e0ce663c7a2f0e9eaf21e6ff87a5f95cbf3675bfd4c41d2", size = 1560531, upload-time = "2023-12-22T23:18:20.555Z" },
-    { url = "https://files.pythonhosted.org/packages/11/92/522a4f1e4b2b8da62e4ec0cb8acf2d257e6d39b31f4214f0fd94d2eeb5bd/black-23.12.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c88b3711d12905b74206227109272673edce0cb29f27e1385f33b0163c414bba", size = 1404644, upload-time = "2023-12-22T23:17:46.425Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/dc/af67d8281e9a24f73d24b060f3f03f6d9ad6be259b3c6acef2845e17d09c/black-23.12.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a920b569dc6b3472513ba6ddea21f440d4b4c699494d2e972a1753cdc25df7b0", size = 1711153, upload-time = "2023-12-22T23:08:34.4Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/0f/94d7c36b421ea187359c413be7b9fc66dc105620c3a30b1c94310265830a/black-23.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:3fa4be75ef2a6b96ea8d92b1587dd8cb3a35c7e3d51f0738ced0781c3aa3a5a3", size = 1332918, upload-time = "2023-12-22T23:10:28.188Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/2c/d9b1a77101e6e5f294f6553d76c39322122bfea2a438aeea4eb6d4b22749/black-23.12.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8d4df77958a622f9b5a4c96edb4b8c0034f8434032ab11077ec6c56ae9f384ba", size = 1541926, upload-time = "2023-12-22T23:23:17.72Z" },
-    { url = "https://files.pythonhosted.org/packages/72/e2/d981a3ff05ba9abe3cfa33e70c986facb0614fd57c4f802ef435f4dd1697/black-23.12.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:602cfb1196dc692424c70b6507593a2b29aac0547c1be9a1d1365f0d964c353b", size = 1388465, upload-time = "2023-12-22T23:19:00.611Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/59/1f5c8eb7bba8a8b1bb5c87f097d16410c93a48a6655be3773db5d2783deb/black-23.12.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c4352800f14be5b4864016882cdba10755bd50805c95f728011bcb47a4afd59", size = 1691993, upload-time = "2023-12-22T23:08:32.018Z" },
-    { url = "https://files.pythonhosted.org/packages/37/bf/a80abc6fcdb00f0d4d3d74184b172adbf2197f6b002913fa0fb6af4dc6db/black-23.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:0808494f2b2df923ffc5723ed3c7b096bd76341f6213989759287611e9837d50", size = 1340929, upload-time = "2023-12-22T23:09:37.088Z" },
-    { url = "https://files.pythonhosted.org/packages/66/16/8726cedc83be841dfa854bbeef1288ee82272282a71048d7935292182b0b/black-23.12.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:25e57fd232a6d6ff3f4478a6fd0580838e47c93c83eaf1ccc92d4faf27112c4e", size = 1569989, upload-time = "2023-12-22T23:20:22.158Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/1e/30f5eafcc41b8378890ba39b693fa111f7dca8a2620ba5162075d95ffe46/black-23.12.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d9e13db441c509a3763a7a3d9a49ccc1b4e974a47be4e08ade2a228876500ec", size = 1398647, upload-time = "2023-12-22T23:19:57.225Z" },
-    { url = "https://files.pythonhosted.org/packages/99/de/ddb45cc044256431d96d846ce03164d149d81ca606b5172224d1872e0b58/black-23.12.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1bd9c210f8b109b1762ec9fd36592fdd528485aadb3f5849b2740ef17e674e", size = 1720450, upload-time = "2023-12-22T23:08:52.675Z" },
-    { url = "https://files.pythonhosted.org/packages/98/2b/54e5dbe9be5a10cbea2259517206ff7b6a452bb34e07508c7e1395950833/black-23.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:ae76c22bde5cbb6bfd211ec343ded2163bba7883c7bc77f6b756a1049436fbb9", size = 1351070, upload-time = "2023-12-22T23:09:32.762Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/14/4da7b12a9abc43a601c215cb5a3d176734578da109f0dbf0a832ed78be09/black-23.12.1-py3-none-any.whl", hash = "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e", size = 194363, upload-time = "2023-12-22T23:06:14.278Z" },
-]
-
-[[package]]
 name = "boolean-py"
 version = "5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -204,18 +174,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/a0/2410e5e6032a174c95e0806b1a6585eb21e12f445ebe239fac441995226a/charset_normalizer-3.4.2-cp312-cp312-win32.whl", hash = "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c", size = 98357, upload-time = "2025-05-02T08:32:53.079Z" },
     { url = "https://files.pythonhosted.org/packages/6c/4f/c02d5c493967af3eda9c771ad4d2bbc8df6f99ddbeb37ceea6e8716a32bc/charset_normalizer-3.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e", size = 105776, upload-time = "2025-05-02T08:32:54.573Z" },
     { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626, upload-time = "2025-05-02T08:34:40.053Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
 ]
 
 [[package]]
@@ -1909,9 +1867,6 @@ dependencies = [
 audit = [
     { name = "pip-audit" },
 ]
-black = [
-    { name = "black" },
-]
 ci-tools = [
     { name = "requests" },
 ]
@@ -1967,7 +1922,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 audit = [{ name = "pip-audit", specifier = ">=2.9.0,<3" }]
-black = [{ name = "black", specifier = ">=23.3,<24" }]
 ci-tools = [{ name = "requests", specifier = ">=2.31.0,<3" }]
 docs = [
     { name = "pydata-sphinx-theme", specifier = ">=0.14.4,<15" },


### PR DESCRIPTION
Removes Black as a dev dependency and switches formatting to use `ruff format`. Uses fully default settings, the diff is just the result of slight differences between the two formatters.