### PR TITLE
Refactor Catalog to unify QEC parameters

### DIFF
--- a/doc/tutorials/privacy-budget-basics.rst
+++ b/doc/tutorials/privacy-budget-basics.rst
@@ -107,6 +107,7 @@ Let's check that we initialized the Session as intended using the
    books_borrowed   INTEGER        True
    favorite_genres  VARCHAR        True
    date_joined      DATE           True
+   No public tables are available.
 
 Initializing a Session with a finite privacy budget gives a simple interface
 promise: all queries evaluated on this Session, *taken together*, will provide

--- a/doc/tutorials/privacy-id-basics.rst
+++ b/doc/tutorials/privacy-id-basics.rst
@@ -114,6 +114,7 @@ regardless of how many books they've checked out. Let's take a look at our Sessi
     publication_date  INTEGER        False                       True
     publisher         VARCHAR        False                       True
     genres            VARCHAR        False                       True
+    No public tables are available.
 
 We can see that our Session has a single table, ``checkouts``, with 7 columns, and that
 the 'member_id' column is marked as our ID column.

--- a/src/tmlt/analytics/_catalog.py
+++ b/src/tmlt/analytics/_catalog.py
@@ -7,10 +7,12 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Dict, Mapping, Optional, Union
 
+from pyspark.sql import DataFrame
+
 from tmlt.analytics._schema import ColumnDescriptor, ColumnType, Schema
 
 
-@dataclass
+@dataclass(frozen=True)
 class Table(ABC):
     """Metadata for a public or private table."""
 
@@ -18,11 +20,9 @@ class Table(ABC):
     """The source id, or unique identifier, for the table."""
     schema: Schema
     """The analytics schema for the table. Describes the column types."""
-    id_space: Optional[str] = None
-    """The identifier space for the table."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class PublicTable(Table):
     """Metadata for a public table.
 
@@ -30,13 +30,16 @@ class PublicTable(Table):
     require any special privacy protections.
     """
 
+    dataframe: DataFrame
+    """The public data for the table."""
+
     def __post_init__(self):
         """Check inputs to constructor."""
         if self.schema.grouping_column is not None:
             raise ValueError("Public tables cannot have a grouping_column")
 
 
-@dataclass
+@dataclass(frozen=True)
 class PrivateTable(Table):
     """Metadata for a private table.
 
@@ -90,12 +93,14 @@ class Catalog:
         self,
         source_id: str,
         col_types: Mapping[str, Union[ColumnDescriptor, ColumnType]],
+        dataframe: DataFrame,
     ):
         """Adds public table to catalog.
 
         Args:
             source_id: The source id, or unique identifier, for the public table.
             col_types: Mapping from column names to types for the public table.
+            dataframe: Public data source for the table.
 
         Raises:
             ValueError: If there is already a public table with the given source_id.
@@ -103,7 +108,7 @@ class Catalog:
         if source_id in self._public_tables:
             raise ValueError(f"Table '{source_id}' already exists in catalog")
         self._public_tables[source_id] = PublicTable(
-            source_id=source_id, schema=Schema(col_types)
+            source_id=source_id, schema=Schema(col_types), dataframe=dataframe
         )
 
     @property

--- a/src/tmlt/analytics/_catalog.py
+++ b/src/tmlt/analytics/_catalog.py
@@ -5,11 +5,12 @@
 
 from abc import ABC
 from dataclasses import dataclass
-from typing import Dict, Mapping, Optional, Union
+from typing import Collection, Dict, Mapping, Optional, Union
 
 from pyspark.sql import DataFrame
 
 from tmlt.analytics._schema import ColumnDescriptor, ColumnType, Schema
+from tmlt.analytics.constraints import Constraint
 
 
 @dataclass(frozen=True)
@@ -47,6 +48,9 @@ class PrivateTable(Table):
     protected.
     """
 
+    constraints: tuple[Constraint, ...]
+    """The constraints known to hold on this private table."""
+
 
 class Catalog:
     """Specifies schemas and constraints on public and private tables."""
@@ -60,6 +64,7 @@ class Catalog:
         self,
         source_id: str,
         col_types: Mapping[str, Union[ColumnDescriptor, ColumnType]],
+        constraints: Collection[Constraint],
         grouping_column: Optional[str] = None,
         id_column: Optional[str] = None,
         id_space: Optional[str] = None,
@@ -69,6 +74,7 @@ class Catalog:
         Args:
             source_id: The source id, or unique identifier, for the private table.
             col_types: Mapping from column names to types for private table.
+            constraints: The constraints known to hold on the private table.
             grouping_column: Name of the column (if any) that must be grouped by in any
                 groupby aggregations that use this table.
             id_column: Name of the ID column for this table (if any).
@@ -87,6 +93,7 @@ class Catalog:
                 id_column=id_column,
                 id_space=id_space,
             ),
+            constraints=tuple(constraints),
         )
 
     def add_public_table(

--- a/src/tmlt/analytics/_catalog.py
+++ b/src/tmlt/analytics/_catalog.py
@@ -50,17 +50,8 @@ class Catalog:
 
     def __init__(self):
         """Constructor."""
-        self._tables = {}
-
-    def _add_table(self, table: Table):
-        """Adds table to catalog.
-
-        Args:
-            table: The table, public or private.
-        """
-        if table.source_id in self._tables:
-            raise ValueError(f"{table.source_id} already exists in catalog.")
-        self._tables[table.source_id] = table
+        self._private_tables = {}
+        self._public_tables = {}
 
     def add_private_table(
         self,
@@ -70,7 +61,7 @@ class Catalog:
         id_column: Optional[str] = None,
         id_space: Optional[str] = None,
     ):
-        """Adds a private table to catalog. There may only be a single private table.
+        """Adds a private table to catalog.
 
         Args:
             source_id: The source id, or unique identifier, for the private table.
@@ -81,18 +72,18 @@ class Catalog:
             id_space: Name of the identifier space for this table (if any).
 
         Raises:
-            ValueError: If there is already a private table.
+            ValueError: If there is already a private table with the given source_id.
         """
-        self._add_table(
-            PrivateTable(
-                source_id=source_id,
-                schema=Schema(
-                    col_types,
-                    grouping_column=grouping_column,
-                    id_column=id_column,
-                    id_space=id_space,
-                ),
-            )
+        if source_id in self._private_tables:
+            raise ValueError(f"Table '{source_id}' already exists in catalog")
+        self._private_tables[source_id] = PrivateTable(
+            source_id=source_id,
+            schema=Schema(
+                col_types,
+                grouping_column=grouping_column,
+                id_column=id_column,
+                id_space=id_space,
+            ),
         )
 
     def add_public_table(
@@ -107,11 +98,20 @@ class Catalog:
             col_types: Mapping from column names to types for the public table.
 
         Raises:
-            ValueError: If there is already a private table.
+            ValueError: If there is already a public table with the given source_id.
         """
-        self._add_table(PublicTable(source_id=source_id, schema=Schema(col_types)))
+        if source_id in self._public_tables:
+            raise ValueError(f"Table '{source_id}' already exists in catalog")
+        self._public_tables[source_id] = PublicTable(
+            source_id=source_id, schema=Schema(col_types)
+        )
 
     @property
-    def tables(self) -> Dict[str, Table]:
-        """Returns the catalog as a dictionary of tables."""
-        return self._tables
+    def private_tables(self) -> Dict[str, PrivateTable]:
+        """Returns the catalog's private tables."""
+        return self._private_tables
+
+    @property
+    def public_tables(self) -> Dict[str, PublicTable]:
+        """Returns the catalog's public tables."""
+        return self._public_tables

--- a/src/tmlt/analytics/_query_expr.py
+++ b/src/tmlt/analytics/_query_expr.py
@@ -26,7 +26,7 @@ from tmlt.core.utils.join import domain_after_join
 from typeguard import check_type
 
 from tmlt.analytics import AnalyticsInternalError
-from tmlt.analytics._catalog import Catalog, PrivateTable, PublicTable
+from tmlt.analytics._catalog import Catalog
 from tmlt.analytics._coerce_spark_schema import coerce_spark_schema_or_fail
 from tmlt.analytics._schema import (
     ColumnDescriptor,
@@ -224,18 +224,18 @@ class PrivateSource(QueryExpr):
 
     def _validate(self, catalog: Catalog):
         """Validation checks for this QueryExpr."""
-        if self.source_id not in catalog.tables:
-            raise ValueError(f"Query references nonexistent table '{self.source_id}'")
-        if not isinstance(catalog.tables[self.source_id], PrivateTable):
+        if self.source_id in catalog.public_tables:
             raise ValueError(
-                f"Attempted query on table '{self.source_id}', which is "
-                "not a private table."
+                f"Table '{self.source_id}' is not a private table, and so cannot be "
+                "the starting point of a query"
             )
+        if self.source_id not in catalog.private_tables:
+            raise ValueError(f"Query references nonexistent table '{self.source_id}'")
 
     def schema(self, catalog: Catalog) -> Schema:
         """Returns the schema resulting from evaluating this QueryExpr."""
         self._validate(catalog)
-        return catalog.tables[self.source_id].schema
+        return catalog.private_tables[self.source_id].schema
 
     def accept(self, visitor: "QueryExprVisitor") -> Any:
         """Visits this QueryExpr with visitor."""
@@ -969,12 +969,6 @@ class JoinPublic(SingleChildQueryExpr):
 
     def _validate(self, catalog: Catalog, left_schema: Schema, right_schema: Schema):
         """Validation checks for this QueryExpr."""
-        if isinstance(self.public_table, str):
-            if not isinstance(catalog.tables[self.public_table], PublicTable):
-                raise ValueError(
-                    f"Attempted public join on table '{self.public_table}', "
-                    "which is not a public table"
-                )
         _validate_join(left_schema, right_schema, self.join_columns)
 
     def schema(self, catalog: Catalog) -> Schema:
@@ -985,7 +979,12 @@ class JoinPublic(SingleChildQueryExpr):
         """
         input_schema = self.child.schema(catalog)
         if isinstance(self.public_table, str):
-            right_schema = catalog.tables[self.public_table].schema
+            if self.public_table not in catalog.public_tables:
+                raise ValueError(
+                    f"Attempted public join on table '{self.public_table}', "
+                    "which is not a public table"
+                )
+            right_schema = catalog.public_tables[self.public_table].schema
         else:
             right_schema = Schema(
                 spark_schema_to_analytics_columns(self.public_table.schema)

--- a/src/tmlt/analytics/_query_expr_compiler/_base_measurement_visitor.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_base_measurement_visitor.py
@@ -1,5 +1,7 @@
 """Defines a base class for building measurement visitors."""
 
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import warnings
 from abc import abstractmethod
@@ -9,9 +11,6 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, 
 
 import sympy as sp
 from pyspark.sql import DataFrame, SparkSession
-
-# SPDX-License-Identifier: Apache-2.0
-# Copyright Tumult Labs 2025
 from pyspark.sql.types import (
     BooleanType,
     ByteType,

--- a/src/tmlt/analytics/_query_expr_compiler/_base_measurement_visitor.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_base_measurement_visitor.py
@@ -100,7 +100,6 @@ from tmlt.analytics._query_expr import (
     VarianceMechanism,
 )
 from tmlt.analytics._schema import Schema
-from tmlt.analytics._table_identifier import Identifier
 from tmlt.analytics._table_reference import TableReference
 from tmlt.analytics._transformation_utils import get_table_from_ref
 from tmlt.analytics.constraints import (
@@ -377,7 +376,6 @@ class BaseMeasurementVisitor(QueryExprVisitor):
         output_measure: Union[PureDP, ApproxDP, RhoZCDP],
         default_mechanism: NoiseMechanism,
         catalog: Catalog,
-        table_constraints: Dict[Identifier, List[Constraint]],
     ):
         """Constructor for MeasurementVisitor."""
         self.budget = privacy_budget
@@ -388,7 +386,6 @@ class BaseMeasurementVisitor(QueryExprVisitor):
         self.default_mechanism = default_mechanism
         self.output_measure = output_measure
         self.catalog = catalog
-        self.table_constraints = table_constraints
 
     def _get_zero_budget(self) -> PrivacyBudget:
         """Return a budget with zero epsilon and zero delta."""

--- a/src/tmlt/analytics/_query_expr_compiler/_base_measurement_visitor.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_base_measurement_visitor.py
@@ -376,7 +376,6 @@ class BaseMeasurementVisitor(QueryExprVisitor):
         input_metric: DictMetric,
         output_measure: Union[PureDP, ApproxDP, RhoZCDP],
         default_mechanism: NoiseMechanism,
-        public_sources: Dict[str, DataFrame],
         catalog: Catalog,
         table_constraints: Dict[Identifier, List[Constraint]],
     ):
@@ -387,7 +386,6 @@ class BaseMeasurementVisitor(QueryExprVisitor):
         self.input_domain = input_domain
         self.input_metric = input_metric
         self.default_mechanism = default_mechanism
-        self.public_sources = public_sources
         self.output_measure = output_measure
         self.catalog = catalog
         self.table_constraints = table_constraints

--- a/src/tmlt/analytics/_query_expr_compiler/_base_transformation_visitor.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_base_transformation_visitor.py
@@ -154,8 +154,8 @@ class BaseTransformationVisitor(QueryExprVisitor):
         input_domain: DictDomain,
         input_metric: DictMetric,
         mechanism: NoiseMechanism,
-        public_sources: Dict[str, DataFrame],
         table_constraints: Dict[Identifier, List[Constraint]],
+        catalog: Catalog,
     ):
         """Constructor for a TransformationVisitor.
 
@@ -163,14 +163,14 @@ class BaseTransformationVisitor(QueryExprVisitor):
             input_domain: The input domain that the transformation should have.
             input_metric: The input metric that the transformation should have.
             mechanism: The noise mechanism (only used for FlatMaps).
-            public_sources: Public sources to use for JoinPublic queries.
             table_constraints: A mapping of tables to the existing constraints on them.
+            catalog: The catalog, used for JoinPublic queries.
         """
         self.input_domain = input_domain
         self.input_metric = input_metric
         self.mechanism = mechanism
-        self.public_sources = public_sources
         self.table_constraints = table_constraints
+        self.catalog = catalog
 
     def _new_visitor_after_transformation(self, transformation: Transformation):
         """Return a new visitor that is expecting queries that follow `transformation`.
@@ -191,8 +191,8 @@ class BaseTransformationVisitor(QueryExprVisitor):
             transformation.output_domain,
             transformation.output_metric,
             self.mechanism,
-            self.public_sources,
             self.table_constraints,
+            self.catalog,
         )
 
     def validate_transformation(
@@ -927,7 +927,7 @@ class BaseTransformationVisitor(QueryExprVisitor):
         public_df: DataFrame
         if isinstance(expr.public_table, str):
             try:
-                public_df = self.public_sources[expr.public_table]
+                public_df = self.catalog.public_tables[expr.public_table].dataframe
             except KeyError as e:
                 raise ValueError(
                     f"There is no public source with the identifier {expr.public_table}"

--- a/src/tmlt/analytics/_query_expr_compiler/_base_transformation_visitor.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_base_transformation_visitor.py
@@ -126,7 +126,7 @@ from tmlt.analytics._schema import (
     spark_dataframe_domain_to_analytics_columns,
     spark_schema_to_analytics_columns,
 )
-from tmlt.analytics._table_identifier import Identifier, TemporaryTable
+from tmlt.analytics._table_identifier import NamedTable, TemporaryTable
 from tmlt.analytics._table_reference import (
     TableReference,
     find_named_tables,
@@ -154,7 +154,6 @@ class BaseTransformationVisitor(QueryExprVisitor):
         input_domain: DictDomain,
         input_metric: DictMetric,
         mechanism: NoiseMechanism,
-        table_constraints: Dict[Identifier, List[Constraint]],
         catalog: Catalog,
     ):
         """Constructor for a TransformationVisitor.
@@ -163,13 +162,11 @@ class BaseTransformationVisitor(QueryExprVisitor):
             input_domain: The input domain that the transformation should have.
             input_metric: The input metric that the transformation should have.
             mechanism: The noise mechanism (only used for FlatMaps).
-            table_constraints: A mapping of tables to the existing constraints on them.
             catalog: The catalog, used for JoinPublic queries.
         """
         self.input_domain = input_domain
         self.input_metric = input_metric
         self.mechanism = mechanism
-        self.table_constraints = table_constraints
         self.catalog = catalog
 
     def _new_visitor_after_transformation(self, transformation: Transformation):
@@ -191,7 +188,6 @@ class BaseTransformationVisitor(QueryExprVisitor):
             transformation.output_domain,
             transformation.output_metric,
             self.mechanism,
-            self.table_constraints,
             self.catalog,
         )
 
@@ -336,11 +332,18 @@ class BaseTransformationVisitor(QueryExprVisitor):
                 f"Available tables are: {named_tables}"
             )
         transformation = IdentityTransformation(self.input_metric, self.input_domain)
+        if not isinstance(ref.identifier, NamedTable):
+            raise AnalyticsInternalError(
+                f"Expected a named table reference for '{expr.source_id}', "
+                f"but got {ref.identifier}"
+            )
         try:
-            constraints = self.table_constraints[ref.identifier]
+            constraints = list(
+                self.catalog.private_tables[ref.identifier.name].constraints
+            )
         except KeyError as e:
             raise AnalyticsInternalError(
-                f"Table {ref.identifier} not present in constraints dictionary."
+                f"Table '{ref.identifier.name}' not present in catalog private tables"
             ) from e
         return self.Output(transformation, ref, constraints)
 

--- a/src/tmlt/analytics/_query_expr_compiler/_compiler.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_compiler.py
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 from tmlt.core.domains.collections import DictDomain
 from tmlt.core.measurements.aggregations import NoiseMechanism as CoreNoiseMechanism
@@ -26,7 +26,6 @@ from tmlt.analytics._query_expr_compiler._transformation_visitor import (
     TransformationVisitor,
 )
 from tmlt.analytics._schema import Schema
-from tmlt.analytics._table_identifier import Identifier
 from tmlt.analytics._table_reference import TableReference
 from tmlt.analytics.constraints import Constraint
 from tmlt.analytics.privacy_budget import PrivacyBudget
@@ -121,7 +120,6 @@ class QueryExprCompiler:
         input_domain: DictDomain,
         input_metric: DictMetric,
         catalog: Catalog,
-        table_constraints: Dict[Identifier, List[Constraint]],
     ) -> Tuple[Measurement, NoiseInfo]:
         """Returns a compiled DP measurement and its noise information.
 
@@ -132,7 +130,6 @@ class QueryExprCompiler:
             input_domain: The input domain of the compiled query.
             input_metric: The input metric of the compiled query.
             catalog: The catalog, used only for query validation.
-            table_constraints: A mapping of tables to the existing constraints on them.
         """
         # Computing the schema validates that the query is well-formed.
         query.schema(catalog)
@@ -153,7 +150,6 @@ class QueryExprCompiler:
             output_measure=self._output_measure,
             default_mechanism=self._mechanism,
             catalog=catalog,
-            table_constraints=table_constraints,
         )
 
         measurement, noise_info = query.accept(visitor)
@@ -187,7 +183,6 @@ class QueryExprCompiler:
         input_domain: DictDomain,
         input_metric: DictMetric,
         catalog: Catalog,
-        table_constraints: Dict[Identifier, List[Constraint]],
     ) -> Tuple[Transformation, TableReference, List[Constraint]]:
         r"""Returns a transformation and reference for the query.
 
@@ -208,7 +203,6 @@ class QueryExprCompiler:
             input_domain: The input domain of the compiled query.
             input_metric: The input metric of the compiled query.
             catalog: The catalog, used only for query validation.
-            table_constraints: A mapping of tables to the existing constraints on them.
         """
         # Computing the schema validates that the query is well-formed. It's useful to
         # perform this check here in addition to __call__ so validation errors can be
@@ -219,7 +213,6 @@ class QueryExprCompiler:
             input_domain=input_domain,
             input_metric=input_metric,
             mechanism=self.mechanism,
-            table_constraints=table_constraints,
             catalog=catalog,
         )
         transformation, reference, constraints = query.accept(transformation_visitor)

--- a/src/tmlt/analytics/_query_expr_compiler/_compiler.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_compiler.py
@@ -9,7 +9,6 @@
 
 from typing import Any, Dict, List, Tuple, Union
 
-from pyspark.sql import DataFrame
 from tmlt.core.domains.collections import DictDomain
 from tmlt.core.measurements.aggregations import NoiseMechanism as CoreNoiseMechanism
 from tmlt.core.measurements.base import Measurement
@@ -121,7 +120,6 @@ class QueryExprCompiler:
         stability: Any,
         input_domain: DictDomain,
         input_metric: DictMetric,
-        public_sources: Dict[str, DataFrame],
         catalog: Catalog,
         table_constraints: Dict[Identifier, List[Constraint]],
     ) -> Tuple[Measurement, NoiseInfo]:
@@ -133,7 +131,6 @@ class QueryExprCompiler:
             stability: The stability of the input to compiled query.
             input_domain: The input domain of the compiled query.
             input_metric: The input metric of the compiled query.
-            public_sources: Public data sources for the queries.
             catalog: The catalog, used only for query validation.
             table_constraints: A mapping of tables to the existing constraints on them.
         """
@@ -155,7 +152,6 @@ class QueryExprCompiler:
             input_metric=input_metric,
             output_measure=self._output_measure,
             default_mechanism=self._mechanism,
-            public_sources=public_sources,
             catalog=catalog,
             table_constraints=table_constraints,
         )
@@ -190,7 +186,6 @@ class QueryExprCompiler:
         query: QueryExpr,
         input_domain: DictDomain,
         input_metric: DictMetric,
-        public_sources: Dict[str, DataFrame],
         catalog: Catalog,
         table_constraints: Dict[Identifier, List[Constraint]],
     ) -> Tuple[Transformation, TableReference, List[Constraint]]:
@@ -212,7 +207,6 @@ class QueryExprCompiler:
             query: A query representing a transformation to compile.
             input_domain: The input domain of the compiled query.
             input_metric: The input metric of the compiled query.
-            public_sources: Public data sources for the queries.
             catalog: The catalog, used only for query validation.
             table_constraints: A mapping of tables to the existing constraints on them.
         """
@@ -225,8 +219,8 @@ class QueryExprCompiler:
             input_domain=input_domain,
             input_metric=input_metric,
             mechanism=self.mechanism,
-            public_sources=public_sources,
             table_constraints=table_constraints,
+            catalog=catalog,
         )
         transformation, reference, constraints = query.accept(transformation_visitor)
         if not isinstance(transformation, Transformation):

--- a/src/tmlt/analytics/_query_expr_compiler/_measurement_visitor.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_measurement_visitor.py
@@ -46,7 +46,6 @@ class MeasurementVisitor(BaseMeasurementVisitor):
             input_domain=self.input_domain,
             input_metric=self.input_metric,
             mechanism=mechanism,
-            table_constraints=self.table_constraints,
             catalog=self.catalog,
         )
         child, reference, constraints = expr.accept(tv)

--- a/src/tmlt/analytics/_query_expr_compiler/_measurement_visitor.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_measurement_visitor.py
@@ -46,8 +46,8 @@ class MeasurementVisitor(BaseMeasurementVisitor):
             input_domain=self.input_domain,
             input_metric=self.input_metric,
             mechanism=mechanism,
-            public_sources=self.public_sources,
             table_constraints=self.table_constraints,
+            catalog=self.catalog,
         )
         child, reference, constraints = expr.accept(tv)
 

--- a/src/tmlt/analytics/session.py
+++ b/src/tmlt/analytics/session.py
@@ -325,6 +325,8 @@ class Session:
         if not isinstance(self._accountant.input_domain, DictDomain):
             raise ValueError("The input domain to a session must be a DictDomain.")
         self._public_sources = public_sources
+        # Note: Currently, only NamedTable identifiers make sense as keys here,
+        #     and we may assume that no other types of identifiers are included.
         self._table_constraints: Dict[Identifier, List[Constraint]] = {
             NamedTable(t): [] for t in self.private_sources
         }
@@ -711,7 +713,6 @@ class Session:
                 query=query_obj,
                 input_domain=self._input_domain,
                 input_metric=self._input_metric,
-                public_sources=self._public_sources,
                 catalog=self._catalog,
                 table_constraints=self._table_constraints,
             )[2]
@@ -906,9 +907,8 @@ class Session:
         for table in self.public_sources:
             catalog.add_public_table(
                 table,
-                spark_schema_to_analytics_columns(
-                    self.public_source_dataframes[table].schema
-                ),
+                spark_schema_to_analytics_columns(self._public_sources[table].schema),
+                self._public_sources[table],
             )
         return catalog
 
@@ -994,7 +994,6 @@ class Session:
             stability=self._accountant.d_in,
             input_domain=self._input_domain,
             input_metric=self._input_metric,
-            public_sources=self._public_sources,
             catalog=self._catalog,
             table_constraints=self._table_constraints,
         )
@@ -1232,7 +1231,6 @@ class Session:
             query=query,
             input_domain=self._input_domain,
             input_metric=self._input_metric,
-            public_sources=self._public_sources,
             catalog=self._catalog,
             table_constraints=self._table_constraints,
         )

--- a/src/tmlt/analytics/session.py
+++ b/src/tmlt/analytics/session.py
@@ -714,7 +714,6 @@ class Session:
                 input_domain=self._input_domain,
                 input_metric=self._input_metric,
                 catalog=self._catalog,
-                table_constraints=self._table_constraints,
             )[2]
         except NotImplementedError:
             # If the query results in a measurement, this will happen.
@@ -900,6 +899,7 @@ class Session:
             catalog.add_private_table(
                 table,
                 self.get_schema(table),
+                constraints=self._table_constraints[NamedTable(table)],
                 grouping_column=self.get_grouping_column(table),
                 id_column=self.get_id_column(table),
                 id_space=self.get_id_space(table),
@@ -995,7 +995,6 @@ class Session:
             input_domain=self._input_domain,
             input_metric=self._input_metric,
             catalog=self._catalog,
-            table_constraints=self._table_constraints,
         )
         return measurement, adjusted_budget, noise_info
 
@@ -1232,7 +1231,6 @@ class Session:
             input_domain=self._input_domain,
             input_metric=self._input_metric,
             catalog=self._catalog,
-            table_constraints=self._table_constraints,
         )
         if cache:
             transformation, ref = persist_table(

--- a/src/tmlt/analytics/session.py
+++ b/src/tmlt/analytics/session.py
@@ -47,7 +47,7 @@ from tmlt.analytics._base_builder import (
     PrivacyBudgetMixin,
     PrivateDataFrame,
 )
-from tmlt.analytics._catalog import Catalog, PrivateTable, PublicTable
+from tmlt.analytics._catalog import Catalog
 from tmlt.analytics._coerce_spark_schema import coerce_spark_schema_or_fail
 from tmlt.analytics._neighboring_relation import (
     AddRemoveKeys,
@@ -597,6 +597,7 @@ class Session:
             A              VARCHAR        True
             B              INTEGER        True
             X              INTEGER        True
+            No public tables are available.
             >>> # describe a query object
             >>> query = QueryBuilder("my_private_data").drop_null_and_nan(["B", "X"])
             >>> sess.describe(query) # doctest: +NORMALIZE_WHITESPACE
@@ -654,51 +655,45 @@ class Session:
             raise AnalyticsInternalError(f"Unrecognized accountant state {out}. ")
         budget: PrivacyBudget = self.remaining_privacy_budget
         out.append(f"The session has a remaining privacy budget of {budget}.")
-        if len(self._catalog.tables) == 0:
-            out.append("The session has no tables available.")
+
+        public_table_descs = []
+        private_table_descs = []
+        for name, public_table in self._catalog.public_tables.items():
+            table_schema = _describe_schema(public_table.schema)
+            table_desc = f"Public table '{name}':\n" + table_schema
+            public_table_descs.append(table_desc)
+        for name, private_table in self._catalog.private_tables.items():
+            table_schema = _describe_schema(private_table.schema)
+            table_desc = f"Table '{name}':\n"
+            table_desc += table_schema
+
+            constraints = self._table_constraints.get(NamedTable(name))
+            if not constraints:
+                table_desc = f"Table '{name}' (no constraints):\n" + table_schema
+            else:
+                table_desc = f"Table '{name}':\n" + table_schema + "\n\tConstraints:\n"
+                constraints_strs = [f"\t\t- {e}" for e in constraints]
+                table_desc += "\n".join(constraints_strs)
+
+            private_table_descs.append(table_desc)
+
+        if len(private_table_descs) != 0:
+            out.append(
+                "The following private tables are available:\n"
+                + "\n".join(private_table_descs)
+            )
         else:
-            public_table_descs = []
-            private_table_descs = []
-            for name, table in self._catalog.tables.items():
-                table_schema = _describe_schema(table.schema)
-                if isinstance(table, PublicTable):
-                    table_desc = f"Public table '{name}':\n" + table_schema
-                    public_table_descs.append(table_desc)
-                elif isinstance(table, PrivateTable):
-                    table_desc = f"Table '{name}':\n"
-                    table_desc += table_schema
+            raise AnalyticsInternalError(
+                "Sessions should never contain no private tables"
+            )
+        if len(public_table_descs) != 0:
+            out.append(
+                "The following public tables are available:\n"
+                + "\n".join(public_table_descs)
+            )
+        else:
+            out.append("No public tables are available.")
 
-                    constraints: Optional[List[Constraint]] = (
-                        self._table_constraints.get(NamedTable(name))
-                    )
-                    if not constraints:
-                        table_desc = (
-                            f"Table '{name}' (no constraints):\n" + table_schema
-                        )
-                    else:
-                        table_desc = (
-                            f"Table '{name}':\n" + table_schema + "\n\tConstraints:\n"
-                        )
-                        constraints_strs = [f"\t\t- {e}" for e in constraints]
-                        table_desc += "\n".join(constraints_strs)
-
-                    private_table_descs.append(table_desc)
-                else:
-                    raise AssertionError(
-                        f"Table {name} has an unrecognized type: {type(table)}. This is"
-                        " probably a bug; please let us know about it so we can"
-                        " fix it!"
-                    )
-            if len(private_table_descs) != 0:
-                out.append(
-                    "The following private tables are available:\n"
-                    + "\n".join(private_table_descs)
-                )
-            if len(public_table_descs) != 0:
-                out.append(
-                    "The following public tables are available:\n"
-                    + "\n".join(public_table_descs)
-                )
         return "\n".join(out)
 
     def _describe_query_obj(

--- a/test/unit/query_expr_compiler/test_measurement_visitor.py
+++ b/test/unit/query_expr_compiler/test_measurement_visitor.py
@@ -261,6 +261,7 @@ def prepare_visitor(spark, request):
                 ColumnType.DECIMAL, allow_null=True, allow_nan=True, allow_inf=True
             ),
         },
+        constraints=[],
     )
     catalog.add_private_table(
         "private_2",
@@ -268,6 +269,7 @@ def prepare_visitor(spark, request):
             "A": ColumnDescriptor(ColumnType.VARCHAR),
             "C": ColumnDescriptor(ColumnType.INTEGER),
         },
+        constraints=[],
     )
     catalog.add_public_table(
         "public",
@@ -292,7 +294,6 @@ def prepare_visitor(spark, request):
         output_measure=PureDP(),
         default_mechanism=NoiseMechanism.LAPLACE,
         catalog=catalog,
-        table_constraints={t: [] for t in stability},
     )
     # for the methods which alter the output measure of a visitor.
     request.cls.pick_noise_visitor = MeasurementVisitor(
@@ -303,7 +304,6 @@ def prepare_visitor(spark, request):
         output_measure=PureDP(),
         default_mechanism=NoiseMechanism.LAPLACE,
         catalog=catalog,
-        table_constraints={t: [] for t in stability},
     )
 
 

--- a/test/unit/query_expr_compiler/test_measurement_visitor.py
+++ b/test/unit/query_expr_compiler/test_measurement_visitor.py
@@ -227,17 +227,15 @@ def prepare_visitor(spark, request):
         }
     )
 
-    public_sources = {
-        "public": spark.createDataFrame(
-            pd.DataFrame({"A": ["zero", "one"], "B": [0, 1]}),
-            schema=StructType(
-                [
-                    StructField("A", StringType(), False),
-                    StructField("B", LongType(), False),
-                ]
-            ),
-        )
-    }
+    public_df = spark.createDataFrame(
+        pd.DataFrame({"A": ["zero", "one"], "B": [0, 1]}),
+        schema=StructType(
+            [
+                StructField("A", StringType(), False),
+                StructField("B", LongType(), False),
+            ]
+        ),
+    )
     request.cls.base_query = PrivateSource(source_id="private")
 
     catalog = Catalog()
@@ -277,6 +275,7 @@ def prepare_visitor(spark, request):
             "A": ColumnDescriptor(ColumnType.VARCHAR),
             "B": ColumnDescriptor(ColumnType.INTEGER),
         },
+        public_df,
     )
     request.cls.catalog = catalog
 
@@ -292,7 +291,6 @@ def prepare_visitor(spark, request):
         input_metric=input_metric,
         output_measure=PureDP(),
         default_mechanism=NoiseMechanism.LAPLACE,
-        public_sources=public_sources,
         catalog=catalog,
         table_constraints={t: [] for t in stability},
     )
@@ -304,7 +302,6 @@ def prepare_visitor(spark, request):
         input_metric=input_metric,
         output_measure=PureDP(),
         default_mechanism=NoiseMechanism.LAPLACE,
-        public_sources=public_sources,
         catalog=catalog,
         table_constraints={t: [] for t in stability},
     )

--- a/test/unit/query_expr_compiler/test_rewrite_rules.py
+++ b/test/unit/query_expr_compiler/test_rewrite_rules.py
@@ -55,6 +55,7 @@ def fixture_catalog():
             "int_col": ColumnDescriptor(ColumnType.INTEGER),
             "float_col": ColumnDescriptor(ColumnType.DECIMAL),
         },
+        constraints=[],
     )
     return c
 
@@ -432,7 +433,7 @@ def test_special_value_handling_count_unaffected(
         mechanism=AggMech["DEFAULT"],
     )
     catalog = Catalog()
-    catalog.add_private_table("private", {"col": col_desc})
+    catalog.add_private_table("private", {"col": col_desc}, constraints=[])
     info = CompilationInfo(output_measure=PureDP(), catalog=catalog)
     got_expr = add_special_value_handling(info)(expr)
     assert got_expr == expr
@@ -539,7 +540,7 @@ def test_special_value_handling_numeric_aggregations(
         mechanism=AggMech["DEFAULT"],
     )
     catalog = Catalog()
-    catalog.add_private_table("private", {"col": col_desc})
+    catalog.add_private_table("private", {"col": col_desc}, constraints=[])
     info = CompilationInfo(output_measure=PureDP(), catalog=catalog)
     got_expr = add_special_value_handling(info)(expr)
     assert got_expr == replace(
@@ -628,7 +629,7 @@ def test_special_value_handling_get_bounds(
         upper_bound_column="upper",
     )
     catalog = Catalog()
-    catalog.add_private_table("private", {"col": col_desc})
+    catalog.add_private_table("private", {"col": col_desc}, constraints=[])
     info = CompilationInfo(output_measure=PureDP(), catalog=catalog)
     got_expr = add_special_value_handling(info)(expr)
     assert got_expr == replace(

--- a/test/unit/query_expr_compiler/transformation_visitor/conftest.py
+++ b/test/unit/query_expr_compiler/transformation_visitor/conftest.py
@@ -186,6 +186,7 @@ def _catalog(request, spark):
             "D": ColumnDescriptor(ColumnType.DATE, allow_null=True),
             "T": ColumnDescriptor(ColumnType.TIMESTAMP, allow_null=True),
         },
+        constraints=[],
     )
     catalog.add_private_table(
         "rows2",
@@ -193,6 +194,7 @@ def _catalog(request, spark):
             "I": ColumnDescriptor(ColumnType.INTEGER, allow_null=True),
             "field": ColumnDescriptor(ColumnType.VARCHAR, allow_null=True),
         },
+        constraints=[],
     )
     catalog.add_private_table(
         "rows_infs_nans",
@@ -205,6 +207,7 @@ def _catalog(request, spark):
                 ColumnType.DECIMAL, allow_nan=True, allow_null=True
             ),
         },
+        constraints=[],
     )
     catalog.add_private_table(
         "ids1",
@@ -218,6 +221,7 @@ def _catalog(request, spark):
             "D": ColumnDescriptor(ColumnType.DATE, allow_null=True),
             "T": ColumnDescriptor(ColumnType.TIMESTAMP, allow_null=True),
         },
+        constraints=[],
         grouping_column="id",
     )
     catalog.add_private_table(
@@ -227,6 +231,7 @@ def _catalog(request, spark):
             "I": ColumnDescriptor(ColumnType.INTEGER, allow_null=True),
             "field": ColumnDescriptor(ColumnType.VARCHAR, allow_null=True),
         },
+        constraints=[],
         grouping_column="id",
     )
     catalog.add_private_table(
@@ -241,6 +246,7 @@ def _catalog(request, spark):
                 ColumnType.DECIMAL, allow_nan=True, allow_null=True
             ),
         },
+        constraints=[],
         grouping_column="id",
     )
     catalog.add_private_table(
@@ -249,6 +255,7 @@ def _catalog(request, spark):
             "id": ColumnDescriptor(ColumnType.INTEGER, allow_null=True),
             "St": ColumnDescriptor(ColumnType.VARCHAR, allow_null=True),
         },
+        constraints=[],
         grouping_column="id",
     )
     catalog.add_public_table(
@@ -364,18 +371,6 @@ def _visitor(request, _catalog):
         input_domain=input_domain,
         input_metric=input_metric,
         mechanism=NoiseMechanism.LAPLACE,
-        table_constraints={
-            NamedTable(t): []
-            for t in (
-                "rows1",
-                "rows2",
-                "rows_infs_nans",
-                "ids1",
-                "ids2",
-                "ids_infs_nans",
-                "ids_duplicates",
-            )
-        },
         catalog=_catalog,
     )
     request.cls.visitor = visitor
@@ -422,10 +417,11 @@ def _nulls_catalog(request):
         ),
     }
     catalog = Catalog()
-    catalog.add_private_table("rows", df_columns)
+    catalog.add_private_table("rows", df_columns, constraints=[])
     catalog.add_private_table(
         "ids",
         {"id": ColumnDescriptor(ColumnType.INTEGER, allow_null=True), **df_columns},
+        constraints=[],
         grouping_column="id",
     )
     request.cls.catalog = catalog
@@ -472,7 +468,6 @@ def _nulls_visitor(request, _nulls_catalog):
         input_domain=input_domain,
         input_metric=input_metric,
         mechanism=NoiseMechanism.LAPLACE,
-        table_constraints={NamedTable(t): [] for t in ("rows", "ids")},
         catalog=_nulls_catalog,
     )
     request.cls.visitor = visitor

--- a/test/unit/query_expr_compiler/transformation_visitor/conftest.py
+++ b/test/unit/query_expr_compiler/transformation_visitor/conftest.py
@@ -172,7 +172,7 @@ def _dataframes(request, spark):
 
 
 @pytest.fixture(scope="class")
-def _catalog(request):
+def _catalog(request, spark):
     """Returns a catalog for use in test functions."""
     catalog = Catalog()
     catalog.add_private_table(
@@ -258,12 +258,23 @@ def _catalog(request):
             "I": ColumnDescriptor(ColumnType.INTEGER, allow_null=True),
             "public": ColumnDescriptor(ColumnType.VARCHAR),
         },
+        spark.createDataFrame(
+            pd.DataFrame({"S": ["0", "1"], "I": [0, 1], "public": ["x", "y"]}),
+            schema=StructType(
+                [
+                    StructField("S", StringType(), True),
+                    StructField("I", LongType(), True),
+                    StructField("public", StringType(), False),
+                ]
+            ),
+        ),
     )
     request.cls.catalog = catalog
+    return catalog
 
 
 @pytest.fixture(scope="class")
-def _visitor(spark, request):
+def _visitor(request, _catalog):
     """Returns a TransformationVisitor for use in test functions."""
     input_domain = DictDomain(
         {
@@ -349,23 +360,10 @@ def _visitor(spark, request):
             ),
         }
     )
-    public_sources = {
-        "public": spark.createDataFrame(
-            pd.DataFrame({"S": ["0", "1"], "I": [0, 1], "public": ["x", "y"]}),
-            schema=StructType(
-                [
-                    StructField("S", StringType(), True),
-                    StructField("I", LongType(), True),
-                    StructField("public", StringType(), False),
-                ]
-            ),
-        )
-    }
     visitor = TransformationVisitor(
         input_domain=input_domain,
         input_metric=input_metric,
         mechanism=NoiseMechanism.LAPLACE,
-        public_sources=public_sources,
         table_constraints={
             NamedTable(t): []
             for t in (
@@ -378,6 +376,7 @@ def _visitor(spark, request):
                 "ids_duplicates",
             )
         },
+        catalog=_catalog,
     )
     request.cls.visitor = visitor
 
@@ -430,10 +429,11 @@ def _nulls_catalog(request):
         grouping_column="id",
     )
     request.cls.catalog = catalog
+    return catalog
 
 
 @pytest.fixture(scope="class")
-def _nulls_visitor(request):
+def _nulls_visitor(request, _nulls_catalog):
     """Returns a TransformationVisitor for tests of null/NaN/inf behavior."""
     df_columns: Dict[str, SparkColumnDescriptor] = {
         "not_null": SparkFloatColumnDescriptor(allow_null=False),
@@ -472,8 +472,8 @@ def _nulls_visitor(request):
         input_domain=input_domain,
         input_metric=input_metric,
         mechanism=NoiseMechanism.LAPLACE,
-        public_sources={},
         table_constraints={NamedTable(t): [] for t in ("rows", "ids")},
+        catalog=_nulls_catalog,
     )
     request.cls.visitor = visitor
 

--- a/test/unit/query_expr_compiler/transformation_visitor/test_add_keys.py
+++ b/test/unit/query_expr_compiler/transformation_visitor/test_add_keys.py
@@ -416,7 +416,9 @@ class TestAddKeys(TestTransformationVisitor):
     def test_visit_join_public_df(self) -> None:
         """Test generating transformations from a JoinPublic using a dataframe."""
         query = JoinPublic(
-            PrivateSource("ids1"), self.visitor.public_sources["public"], None
+            PrivateSource("ids1"),
+            self.visitor.catalog.public_tables["public"].dataframe,
+            None,
         )
         expected_df = pd.DataFrame(
             [[1, "0", 0, 0.1, DATE1, TIMESTAMP1, "x"]],

--- a/test/unit/test_catalog.py
+++ b/test/unit/test_catalog.py
@@ -20,8 +20,8 @@ def test_add_private_table(grouping_column: Optional["str"]):
         col_types={"A": ColumnDescriptor(ColumnType.VARCHAR)},
         grouping_column=grouping_column,
     )
-    assert len(catalog.tables) == 1
-    private_table = catalog.tables["private"]
+    assert len(catalog.private_tables) == 1
+    private_table = catalog.private_tables["private"]
     assert isinstance(private_table, PrivateTable)
     assert private_table.source_id == "private"
     actual_schema = private_table.schema
@@ -32,11 +32,11 @@ def test_add_private_table(grouping_column: Optional["str"]):
 def test_add_public_table():
     """Adding a public table works as expected."""
     catalog = Catalog()
-    catalog.add_private_table(source_id="public", col_types={"A": ColumnType.VARCHAR})
-    assert len(catalog.tables) == 1
-    assert list(catalog.tables)[0] == "public"
-    assert catalog.tables["public"].source_id == "public"
-    actual_schema = catalog.tables["public"].schema
+    catalog.add_public_table(source_id="public", col_types={"A": ColumnType.VARCHAR})
+    assert len(catalog.public_tables) == 1
+    assert list(catalog.public_tables)[0] == "public"
+    assert catalog.public_tables["public"].source_id == "public"
+    actual_schema = catalog.public_tables["public"].schema
     expected_schema = Schema({"A": ColumnType.VARCHAR})
     assert actual_schema == expected_schema
 
@@ -46,7 +46,9 @@ def test_invalid_addition_private_table():
     catalog = Catalog()
     source_id = "private"
     catalog.add_private_table(source_id=source_id, col_types={"A": ColumnType.VARCHAR})
-    with pytest.raises(ValueError, match=f"{source_id} already exists in catalog."):
+    with pytest.raises(
+        ValueError, match=f"Table '{source_id}' already exists in catalog"
+    ):
         catalog.add_private_table(
             source_id=source_id, col_types={"B": ColumnType.VARCHAR}
         )
@@ -57,5 +59,7 @@ def test_invalid_addition_public_table():
     catalog = Catalog()
     source_id = "public"
     catalog.add_public_table(source_id, {"A": ColumnType.VARCHAR})
-    with pytest.raises(ValueError, match=f"{source_id} already exists in catalog."):
+    with pytest.raises(
+        ValueError, match=f"Table '{source_id}' already exists in catalog"
+    ):
         catalog.add_public_table(source_id, {"C": ColumnType.VARCHAR})

--- a/test/unit/test_catalog.py
+++ b/test/unit/test_catalog.py
@@ -19,12 +19,14 @@ def test_add_private_table(grouping_column: Optional["str"]):
     catalog.add_private_table(
         source_id="private",
         col_types={"A": ColumnDescriptor(ColumnType.VARCHAR)},
+        constraints=[],
         grouping_column=grouping_column,
     )
     assert len(catalog.private_tables) == 1
     private_table = catalog.private_tables["private"]
     assert isinstance(private_table, PrivateTable)
     assert private_table.source_id == "private"
+    assert private_table.constraints == tuple()
     actual_schema = private_table.schema
     expected_schema = Schema({"A": ColumnType.VARCHAR}, grouping_column=grouping_column)
     assert actual_schema == expected_schema
@@ -52,12 +54,14 @@ def test_invalid_addition_private_table():
     """Adding a private table that already exists fails."""
     catalog = Catalog()
     source_id = "private"
-    catalog.add_private_table(source_id=source_id, col_types={"A": ColumnType.VARCHAR})
+    catalog.add_private_table(
+        source_id=source_id, col_types={"A": ColumnType.VARCHAR}, constraints=[]
+    )
     with pytest.raises(
         ValueError, match=f"Table '{source_id}' already exists in catalog"
     ):
         catalog.add_private_table(
-            source_id=source_id, col_types={"B": ColumnType.VARCHAR}
+            source_id=source_id, col_types={"B": ColumnType.VARCHAR}, constraints=[]
         )
 
 

--- a/test/unit/test_catalog.py
+++ b/test/unit/test_catalog.py
@@ -6,6 +6,7 @@
 from typing import Optional
 
 import pytest
+from pyspark.sql.types import StringType, StructField, StructType
 
 from tmlt.analytics._catalog import Catalog, PrivateTable
 from tmlt.analytics._schema import ColumnDescriptor, ColumnType, Schema
@@ -29,16 +30,22 @@ def test_add_private_table(grouping_column: Optional["str"]):
     assert actual_schema == expected_schema
 
 
-def test_add_public_table():
+def test_add_public_table(spark):
     """Adding a public table works as expected."""
     catalog = Catalog()
-    catalog.add_public_table(source_id="public", col_types={"A": ColumnType.VARCHAR})
+    dataframe = spark.createDataFrame(
+        [], schema=StructType([StructField("A", StringType(), True)])
+    )
+    catalog.add_public_table(
+        source_id="public", col_types={"A": ColumnType.VARCHAR}, dataframe=dataframe
+    )
     assert len(catalog.public_tables) == 1
     assert list(catalog.public_tables)[0] == "public"
     assert catalog.public_tables["public"].source_id == "public"
     actual_schema = catalog.public_tables["public"].schema
     expected_schema = Schema({"A": ColumnType.VARCHAR})
     assert actual_schema == expected_schema
+    assert catalog.public_tables["public"].dataframe is dataframe
 
 
 def test_invalid_addition_private_table():
@@ -54,12 +61,15 @@ def test_invalid_addition_private_table():
         )
 
 
-def test_invalid_addition_public_table():
+def test_invalid_addition_public_table(spark):
     """Adding a public table that already exists fails."""
     catalog = Catalog()
     source_id = "public"
-    catalog.add_public_table(source_id, {"A": ColumnType.VARCHAR})
+    dataframe = spark.createDataFrame(
+        [], schema=StructType([StructField("A", StringType(), True)])
+    )
+    catalog.add_public_table(source_id, {"A": ColumnType.VARCHAR}, dataframe)
     with pytest.raises(
         ValueError, match=f"Table '{source_id}' already exists in catalog"
     ):
-        catalog.add_public_table(source_id, {"C": ColumnType.VARCHAR})
+        catalog.add_public_table(source_id, {"C": ColumnType.VARCHAR}, dataframe)

--- a/test/unit/test_query_expr_compiler.py
+++ b/test/unit/test_query_expr_compiler.py
@@ -1308,7 +1308,7 @@ class TestQueryExprCompiler:
     )
     def test_different_source_id(self, query_expr: QueryExpr):
         """Tests that different source ids are allowed."""
-        if not self.catalog.tables.get("doubled"):
+        if not self.catalog.private_tables.get("doubled"):
             self.catalog.add_private_table(
                 source_id="doubled",
                 col_types={

--- a/test/unit/test_query_expr_compiler.py
+++ b/test/unit/test_query_expr_compiler.py
@@ -512,6 +512,7 @@ def setup(spark, request) -> None:
             "B": ColumnDescriptor(ColumnType.INTEGER),
             "A+B": ColumnDescriptor(ColumnType.INTEGER),
         },
+        join_df,
     )
     catalog.add_public_table(
         "dtypes",
@@ -524,6 +525,7 @@ def setup(spark, request) -> None:
             "date": ColumnDescriptor(ColumnType.DATE),
             "timestamp": ColumnDescriptor(ColumnType.TIMESTAMP),
         },
+        dtypes_df,
     )
     catalog.add_public_table(
         "groupby_two_columns",
@@ -531,9 +533,12 @@ def setup(spark, request) -> None:
             "A": ColumnDescriptor(ColumnType.VARCHAR),
             "B": ColumnDescriptor(ColumnType.INTEGER),
         },
+        groupby_two_columns_df,
     )
     catalog.add_public_table(
-        "groupby_one_column", {"A": ColumnDescriptor(ColumnType.VARCHAR)}
+        "groupby_one_column",
+        {"A": ColumnDescriptor(ColumnType.VARCHAR)},
+        groupby_one_column_df,
     )
 
     request.cls.catalog = catalog
@@ -639,11 +644,6 @@ class TestQueryExprCompiler:
             stability=self.stability,
             input_domain=self.input_domain,
             input_metric=self.input_metric,
-            public_sources={
-                "public": self.join_df,
-                "groupby_two_columns": self.groupby_two_columns_df,
-                "groupby_one_column": self.groupby_one_column_df,
-            },
             catalog=self.catalog,
             table_constraints={t: [] for t in self.stability.keys()},
         )
@@ -664,12 +664,6 @@ class TestQueryExprCompiler:
             stability=self.stability,
             input_domain=self.input_domain,
             input_metric=self.input_metric,
-            public_sources={
-                "public": self.join_df,
-                "dtypes": self.dtypes_df,
-                "groupby_two_columns": self.groupby_two_columns_df,
-                "groupby_one_column": self.groupby_one_column_df,
-            },
             catalog=self.catalog,
             table_constraints={t: [] for t in self.stability.keys()},
         )
@@ -994,7 +988,6 @@ class TestQueryExprCompiler:
             stability=self.stability,
             input_domain=self.input_domain,
             input_metric=self.input_metric,
-            public_sources={"public": self.join_df},
             catalog=self.catalog,
             table_constraints={t: [] for t in self.stability.keys()},
         )
@@ -1015,7 +1008,6 @@ class TestQueryExprCompiler:
             JoinPublic(PrivateSource("private"), public_sdf),
             input_domain=self.input_domain,
             input_metric=self.input_metric,
-            public_sources={},
             catalog=self.catalog,
             table_constraints={t: [] for t in self.stability.keys()},
         )
@@ -1052,7 +1044,6 @@ class TestQueryExprCompiler:
             ),
             input_domain=self.input_domain,
             input_metric=self.input_metric,
-            public_sources={},
             catalog=self.catalog,
             table_constraints={t: [] for t in self.stability.keys()},
         )
@@ -1135,7 +1126,6 @@ class TestQueryExprCompiler:
             join_query,
             input_domain=self.input_domain,
             input_metric=self.input_metric,
-            public_sources={},
             catalog=self.catalog,
             table_constraints={t: [] for t in self.stability.keys()},
         )
@@ -1166,7 +1156,6 @@ class TestQueryExprCompiler:
                 query,
                 input_domain=self.input_domain,
                 input_metric=self.input_metric,
-                public_sources={},
                 catalog=self.catalog,
                 table_constraints={t: [] for t in self.stability.keys()},
             )
@@ -1207,7 +1196,6 @@ class TestQueryExprCompiler:
             flatmap_query,
             input_domain=self.input_domain,
             input_metric=self.input_metric,
-            public_sources={},
             catalog=self.catalog,
             table_constraints={t: [] for t in self.stability.keys()},
         )
@@ -1240,7 +1228,6 @@ class TestQueryExprCompiler:
             stability=self.stability,
             input_domain=self.input_domain,
             input_metric=self.input_metric,
-            public_sources={},
             catalog=self.catalog,
             table_constraints={t: [] for t in self.stability.keys()},
         )
@@ -1284,7 +1271,6 @@ class TestQueryExprCompiler:
                 stability=self.stability,
                 input_domain=self.input_domain,
                 input_metric=self.input_metric,
-                public_sources={"public": self.join_df},
                 catalog=self.catalog,
                 table_constraints={t: [] for t in self.stability.keys()},
             )
@@ -1340,7 +1326,6 @@ class TestQueryExprCompiler:
             stability=stability,
             input_domain=input_domain,
             input_metric=input_metric,
-            public_sources={"public": self.join_df},
             catalog=self.catalog,
             table_constraints={t: [] for t in stability.keys()},
         )
@@ -1417,7 +1402,6 @@ class TestCompileGroupByQuantile:
             stability=stability,
             input_domain=input_domain,
             input_metric=input_metric,
-            public_sources={},
             catalog=catalog,
             table_constraints={t: [] for t in stability},
         )

--- a/test/unit/test_query_expr_compiler.py
+++ b/test/unit/test_query_expr_compiler.py
@@ -497,6 +497,7 @@ def setup(spark, request) -> None:
             "B": ColumnDescriptor(ColumnType.INTEGER),
             "X": ColumnDescriptor(ColumnType.DECIMAL),
         },
+        constraints=[],
     )
     catalog.add_private_table(
         "private_2",
@@ -504,6 +505,7 @@ def setup(spark, request) -> None:
             "A": ColumnDescriptor(ColumnType.VARCHAR),
             "C": ColumnDescriptor(ColumnType.INTEGER),
         },
+        constraints=[],
     )
     catalog.add_public_table(
         "public",
@@ -645,7 +647,6 @@ class TestQueryExprCompiler:
             input_domain=self.input_domain,
             input_metric=self.input_metric,
             catalog=self.catalog,
-            table_constraints={t: [] for t in self.stability.keys()},
         )
         actual = measurement({NamedTable("private"): count_distinct_df})
         assert_dataframe_equal(actual, expected)
@@ -665,7 +666,6 @@ class TestQueryExprCompiler:
             input_domain=self.input_domain,
             input_metric=self.input_metric,
             catalog=self.catalog,
-            table_constraints={t: [] for t in self.stability.keys()},
         )
         actual = measurement({NamedTable("private"): self.sdf})
         assert_dataframe_equal(actual, expected)
@@ -989,7 +989,6 @@ class TestQueryExprCompiler:
             input_domain=self.input_domain,
             input_metric=self.input_metric,
             catalog=self.catalog,
-            table_constraints={t: [] for t in self.stability.keys()},
         )
         actual = measurement({NamedTable("private"): self.sdf})
         assert_dataframe_equal(actual, expected)
@@ -1009,7 +1008,6 @@ class TestQueryExprCompiler:
             input_domain=self.input_domain,
             input_metric=self.input_metric,
             catalog=self.catalog,
-            table_constraints={t: [] for t in self.stability.keys()},
         )
 
         source_dict = {NamedTable("private"): self.sdf}
@@ -1045,7 +1043,6 @@ class TestQueryExprCompiler:
             input_domain=self.input_domain,
             input_metric=self.input_metric,
             catalog=self.catalog,
-            table_constraints={t: [] for t in self.stability.keys()},
         )
         source_dict = {NamedTable("private"): self.sdf, NamedTable("private_2"): sdf_2}
         output_sdf = get_table_from_ref(transformation, reference)(source_dict)
@@ -1127,7 +1124,6 @@ class TestQueryExprCompiler:
             input_domain=self.input_domain,
             input_metric=self.input_metric,
             catalog=self.catalog,
-            table_constraints={t: [] for t in self.stability.keys()},
         )
 
         get_value_transform = get_table_from_ref(transformation, reference)
@@ -1157,7 +1153,6 @@ class TestQueryExprCompiler:
                 input_domain=self.input_domain,
                 input_metric=self.input_metric,
                 catalog=self.catalog,
-                table_constraints={t: [] for t in self.stability.keys()},
             )
 
     @pytest.mark.parametrize(
@@ -1197,7 +1192,6 @@ class TestQueryExprCompiler:
             input_domain=self.input_domain,
             input_metric=self.input_metric,
             catalog=self.catalog,
-            table_constraints={t: [] for t in self.stability.keys()},
         )
         get_value_transform = get_table_from_ref(transformation, reference)
 
@@ -1229,7 +1223,6 @@ class TestQueryExprCompiler:
             input_domain=self.input_domain,
             input_metric=self.input_metric,
             catalog=self.catalog,
-            table_constraints={t: [] for t in self.stability.keys()},
         )
         actual = measurement({NamedTable("private"): sdf_float})
         expected = pd.DataFrame({"A": ["0", "1"], "sum": [2.0, 1.0]})
@@ -1272,7 +1265,6 @@ class TestQueryExprCompiler:
                 input_domain=self.input_domain,
                 input_metric=self.input_metric,
                 catalog=self.catalog,
-                table_constraints={t: [] for t in self.stability.keys()},
             )
 
     @pytest.mark.parametrize(
@@ -1302,6 +1294,7 @@ class TestQueryExprCompiler:
                     "B": ColumnType.INTEGER,
                     "X": ColumnType.DECIMAL,
                 },
+                constraints=[],
             )
         stability = {
             NamedTable("doubled"): self.stability[NamedTable("private")] * 2,
@@ -1327,7 +1320,6 @@ class TestQueryExprCompiler:
             input_domain=input_domain,
             input_metric=input_metric,
             catalog=self.catalog,
-            table_constraints={t: [] for t in stability.keys()},
         )
         assert measurement.privacy_relation(stability, sp.Integer(10))
 
@@ -1367,6 +1359,7 @@ class TestCompileGroupByQuantile:
                 "Gender": ColumnDescriptor(ColumnType.VARCHAR),
                 "Age": ColumnDescriptor(ColumnType.INTEGER),
             },
+            constraints=[],
         )
         stability = {NamedTable("private"): sp.Integer(1)}
         input_domain = DictDomain(
@@ -1403,7 +1396,6 @@ class TestCompileGroupByQuantile:
             input_domain=input_domain,
             input_metric=input_metric,
             catalog=catalog,
-            table_constraints={t: [] for t in stability},
         )
         assert measurement.input_domain == input_domain
         assert measurement.input_metric == input_metric
@@ -1433,5 +1425,7 @@ def setup_components(request):
     request.cls._input_metric = DictMetric({NamedTable("test"): SymmetricDifference()})
     request.cls._catalog = Catalog()
     request.cls._catalog.add_private_table(
-        source_id="test", col_types={"A": ColumnType.VARCHAR, "X": ColumnType.INTEGER}
+        source_id="test",
+        col_types={"A": ColumnType.VARCHAR, "X": ColumnType.INTEGER},
+        constraints=[],
     )

--- a/test/unit/test_query_expression_schema.py
+++ b/test/unit/test_query_expression_schema.py
@@ -73,7 +73,7 @@ GET_GROUPBY_COLUMN_WRONG_TYPE = lambda: (
 OUTPUT_SCHEMA_INVALID_QUERY_TESTS = [
     (  # Query references public source instead of private source
         PrivateSource("public"),
-        "Attempted query on table 'public', which is not a private table",
+        "Table 'public' is not a private table",
     ),
     (  # JoinPublic has invalid public_id
         JoinPublic(child=PrivateSource("private"), public_table="private"),
@@ -674,7 +674,7 @@ class TestValidationWithNulls:
         """Test schema for private_source."""
         query = PrivateSource("private")
         schema = query.schema(self.catalog)
-        assert schema == self.catalog.tables["private"].schema
+        assert schema == self.catalog.private_tables["private"].schema
 
     @pytest.mark.parametrize(
         "column_mapper,expected_schema",
@@ -759,7 +759,7 @@ class TestValidationWithNulls:
         """Test schema for filter."""
         query = Filter(child=PrivateSource("private"), condition=condition)
         schema = query.schema(self.catalog)
-        assert schema == self.catalog.tables["private"].schema
+        assert schema == self.catalog.private_tables["private"].schema
 
     @pytest.mark.parametrize(
         "columns,expected_schema",

--- a/test/unit/test_query_expression_schema.py
+++ b/test/unit/test_query_expression_schema.py
@@ -42,6 +42,7 @@ from tmlt.analytics._schema import (
     ColumnType,
     FrozenDict,
     Schema,
+    analytics_to_spark_schema,
     spark_schema_to_analytics_columns,
 )
 from tmlt.analytics.config import config
@@ -69,6 +70,13 @@ GET_GROUPBY_COLUMN_WRONG_TYPE = lambda: (
         [], schema=StructType([StructField("A", LongType(), False)])
     )
 )
+
+
+def _empty_public_dataframe(col_types):
+    return SparkSession.builder.getOrCreate().createDataFrame(
+        [], schema=analytics_to_spark_schema(Schema(col_types))
+    )
+
 
 OUTPUT_SCHEMA_INVALID_QUERY_TESTS = [
     (  # Query references public source instead of private source
@@ -337,23 +345,27 @@ def setup_validation(request):
         },
     )
     catalog.add_public_table(
-        "public", spark_schema_to_analytics_columns(GET_PUBLIC().schema)
+        "public", spark_schema_to_analytics_columns(GET_PUBLIC().schema), GET_PUBLIC()
     )
     catalog.add_public_table(
         "groupby_column_a",
         spark_schema_to_analytics_columns(GET_GROUPBY_COLUMN_A().schema),
+        GET_GROUPBY_COLUMN_A(),
     )
     catalog.add_public_table(
         "groupby_column_b",
         spark_schema_to_analytics_columns(GET_GROUPBY_COLUMN_B().schema),
+        GET_GROUPBY_COLUMN_B(),
     )
     catalog.add_public_table(
         "groupby_non_existing_column",
         spark_schema_to_analytics_columns(GET_GROUPBY_NON_EXISTING_COLUMN().schema),
+        GET_GROUPBY_NON_EXISTING_COLUMN(),
     )
     catalog.add_public_table(
         "groupby_column_wrong_type",
         spark_schema_to_analytics_columns(GET_GROUPBY_COLUMN_WRONG_TYPE().schema),
+        GET_GROUPBY_COLUMN_WRONG_TYPE(),
     )
     catalog.add_private_table(
         "groupby_one_column_private", {"A": ColumnDescriptor(ColumnType.VARCHAR)}
@@ -516,29 +528,28 @@ def setup_catalog_with_nulls(request) -> None:
             "NOTNULL": ColumnDescriptor(ColumnType.INTEGER, allow_null=False),
         },
     )
-    catalog.add_public_table(
-        "public",
-        {
-            "A": ColumnDescriptor(ColumnType.INTEGER, allow_null=True),
-            "A+B": ColumnDescriptor(ColumnType.INTEGER, allow_null=True),
-        },
-    )
-    catalog.add_public_table(
-        "groupby_column_a", {"A": ColumnDescriptor(ColumnType.VARCHAR, allow_null=True)}
-    )
-    catalog.add_public_table(
-        "groupby_column_b", {"B": ColumnDescriptor(ColumnType.INTEGER, allow_null=True)}
-    )
-    catalog.add_public_table(
-        "groupby_nonexistent_column", {"yay": ColumnDescriptor(ColumnType.INTEGER)}
-    )
-    catalog.add_public_table(
-        "groupby_column_wrong_type", {"A": ColumnDescriptor(ColumnType.INTEGER)}
-    )
     catalog.add_private_table(
         "groupby_one_column_private",
         {"A": ColumnDescriptor(ColumnType.VARCHAR, allow_null=True)},
     )
+
+    public_schemas = {
+        "public": {
+            "A": ColumnDescriptor(ColumnType.INTEGER, allow_null=True),
+            "A+B": ColumnDescriptor(ColumnType.INTEGER, allow_null=True),
+        },
+        "groupby_column_a": {
+            "A": ColumnDescriptor(ColumnType.VARCHAR, allow_null=True)
+        },
+        "groupby_column_b": {
+            "B": ColumnDescriptor(ColumnType.INTEGER, allow_null=True)
+        },
+        "groupby_nonexistent_column": {"yay": ColumnDescriptor(ColumnType.INTEGER)},
+        "groupby_column_wrong_type": {"A": ColumnDescriptor(ColumnType.INTEGER)},
+    }
+    for source_id, schema in public_schemas.items():
+        catalog.add_public_table(source_id, schema, _empty_public_dataframe(schema))
+
     request.cls.catalog = catalog
 
 
@@ -1187,7 +1198,9 @@ class TestValidationWithNulls:
         """Test that schema correctly propagates nulls through a join."""
         catalog = Catalog()
         catalog.add_private_table("private", private_schema)
-        catalog.add_public_table("public", public_schema)
+        catalog.add_public_table(
+            "public", public_schema, _empty_public_dataframe(public_schema)
+        )
         query = JoinPublic(child=PrivateSource("private"), public_table="public")
         result_schema = query.schema(catalog)
         assert result_schema == expected_schema

--- a/test/unit/test_query_expression_schema.py
+++ b/test/unit/test_query_expression_schema.py
@@ -343,6 +343,7 @@ def setup_validation(request):
             "D": ColumnDescriptor(ColumnType.DATE),
             "T": ColumnDescriptor(ColumnType.TIMESTAMP),
         },
+        constraints=[],
     )
     catalog.add_public_table(
         "public", spark_schema_to_analytics_columns(GET_PUBLIC().schema), GET_PUBLIC()
@@ -368,7 +369,9 @@ def setup_validation(request):
         GET_GROUPBY_COLUMN_WRONG_TYPE(),
     )
     catalog.add_private_table(
-        "groupby_one_column_private", {"A": ColumnDescriptor(ColumnType.VARCHAR)}
+        "groupby_one_column_private",
+        {"A": ColumnDescriptor(ColumnType.VARCHAR)},
+        constraints=[],
     )
     request.cls.catalog = catalog
 
@@ -527,10 +530,12 @@ def setup_catalog_with_nulls(request) -> None:
             "T": ColumnDescriptor(ColumnType.TIMESTAMP, allow_null=True),
             "NOTNULL": ColumnDescriptor(ColumnType.INTEGER, allow_null=False),
         },
+        constraints=[],
     )
     catalog.add_private_table(
         "groupby_one_column_private",
         {"A": ColumnDescriptor(ColumnType.VARCHAR, allow_null=True)},
+        constraints=[],
     )
 
     public_schemas = {
@@ -1135,8 +1140,8 @@ class TestValidationWithNulls:
     ):
         """Test that schema correctly propagates nulls through a join."""
         catalog = Catalog()
-        catalog.add_private_table("left", left_schema)
-        catalog.add_private_table("right", right_schema)
+        catalog.add_private_table("left", left_schema, constraints=[])
+        catalog.add_private_table("right", right_schema, constraints=[])
         query = JoinPrivate(
             left_child=PrivateSource("left"),
             right_child=PrivateSource("right"),
@@ -1197,7 +1202,7 @@ class TestValidationWithNulls:
     ):
         """Test that schema correctly propagates nulls through a join."""
         catalog = Catalog()
-        catalog.add_private_table("private", private_schema)
+        catalog.add_private_table("private", private_schema, constraints=[])
         catalog.add_public_table(
             "public", public_schema, _empty_public_dataframe(public_schema)
         )


### PR DESCRIPTION
This MR covers three small changes to `Catalog` that aim to simplify the QEC API and the process of moving compilation logic into rewrite rules and `QueryExpr` methods:
* Splitting `Catalog.tables` into separate `private_tables` and `public_tables` properties
* Adding public table dataframes to `Catalog`
* Adding information about private table constraints to `Catalog`

Some more details on these changes are included in the individual commit messages. Nothing should have any user-facing impact aside from possibly a few error messages being reworded.

This is preliminary work for some further refactoring of the query compilation process:
* Moving constraint tracking onto `QueryExpr` rather than having it tied in with the transformation visitor (suggested in [this comment](https://github.com/opendp/tumult-analytics/issues/23#issuecomment-3462739736)). By incorporating base table constraints into the catalog, `QueryExpr.constraints()` should be able to just take in a Catalog object as its only parameter, the same way `QueryExpr.schema()` does.
* Pulling various decision-making in the measurement visitor out into rewrite rules (e.g. what currently lives in `_generate_constrained_count_distinct`) -- the rewrite rules don't currently have enough context to support this, and I felt that making `Catalog` the main source of per-table information was clearer than adding constraints, etc. to that context object separately.