### PR TITLE
Use Java 17 for pyspark 4 runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,11 @@ jobs:
         os: [ubuntu-latest]
         dependencies: [oldest, newest]
         python: ["3.10", "3.12"]
+        include:
+          - python: "3.10"
+            java-version: "8"
+          - python: "3.12"
+            java-version: "17"
     runs-on: ${{ matrix.os }}
     needs: Package
     steps:


### PR DESCRIPTION
This should fix the dependency matrix in the release pipeline.