### PR TITLE
Fix setting Java version in CI dependency matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up runner
         uses: opendp/tumult-tools/actions/setup@eabe1054863f0916a0087ad180fd83719049c094
+        with:
+          java-version: ${{ matrix.java-version }}
       - name: Download dist
         uses: actions/download-artifact@v4
         with:
@@ -155,4 +157,3 @@ jobs:
           docs-repository-token: ${{ secrets.DOCS_REPO_PAT }}
           docs-path: docs/analytics
           version: ${{ format('v{0}.{1}', env.MAJOR_VERSION, env.MINOR_VERSION) }}
-


### PR DESCRIPTION
We were not passing the requested `java-version` down to the runner setup step, so it was just defaulting to Java 8.