### PR TITLE
Add even more benchmark time

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -130,7 +130,7 @@ AUDIT_SUPPRESSIONS = [
 # timeouts have been set in https://github.com/opendp/tumult-analytics/pull/49
 # to 25% longer than one run on the GitHub runners (rounded up).
 BENCHMARK_TO_TIMEOUT = {
-    "keyset_projection": 9 * 60,
+    "keyset_projection": 14 * 60,
     "keyset_cross_product_per_size": 45 * 60,
     "keyset_cross_product_per_factors": 37 * 60,
 }


### PR DESCRIPTION
In the tests I ran last night, this benchmark took 10.5 minutes in the CI, so this ensures the benchmark will have enough time to pass and re-establishes our ~20% margin.