### PR TITLE
Adopt stdlib logging with representative Session and compiler sites.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,15 @@ Changelog
 Unreleased
 ----------
 
+Added
+~~~~~
+- Diagnostic messages are emitted via Python's built-in :mod:`logging` module
+  (for example on Session creation and during query compilation/evaluation).
+  Applications should configure logging handlers themselves. When an active
+  SparkSession has a noisy SparkContext log level (``ALL``/``DEBUG``/``INFO``),
+  Analytics emits a one-time warning suggesting ``setLogLevel("ERROR")``.
+  See the Spark deployment guide for details.
+
 .. _v0.21.0:
 
 0.21.0 - 2026-06-30

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,8 @@ Added
   (for example on Session creation and during query compilation/evaluation).
   Applications should configure logging handlers themselves. When an active
   SparkSession has a noisy SparkContext log level (``ALL``/``DEBUG``/``INFO``),
-  Analytics emits a one-time warning suggesting ``setLogLevel("ERROR")``.
-  See the Spark deployment guide for details.
+  Analytics emits a one-time :class:`UserWarning` and :mod:`logging` warning
+  suggesting ``setLogLevel("ERROR")``. See :ref:`spark-logging`.
 
 .. _v0.21.0:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,23 +48,23 @@ Helpers and a short channel summary live in [`src/tmlt/analytics/_logging.py`](.
 | **DEBUG** | High-volume diagnostic detail (query compile/evaluate steps, noise mechanism summary). |
 | **INFO** | Rare, high-signal lifecycle events (e.g. Session created; log budget *type* only). |
 | **WARNING** | Recoverable or suboptimal situations that still continue (e.g. noisy Spark log level). |
-| **ERROR** | Unexpected internal failures (`AnalyticsInternalError`). Not for expected control-flow errors such as insufficient privacy budget — raise those without logging. |
+| **ERROR** | Not used at Analytics call sites. Applications may log at ERROR when they catch failures at their boundary. Internal bugs use `AnalyticsInternalError` (raise only). |
 
 #### Channels
 
 - **`print`** — intentional interactive UX (`Session.describe`, `check_installation`).
 - **`warnings.warn`** — advisories that must be visible without configuring logging.
-- **`logging`** — diagnostics for operators who configure logging.
+- **`logging`** — diagnostics for operators who configure logging (DEBUG / INFO / WARNING in this library).
 
 Do not migrate existing `warnings.warn` call sites to `logger.warning` without considering visibility.
 
 #### Log-once vs raise
 
-Prefer raising (and wrapping with `raise ... from e` when translating errors) in the middle of the stack. Do not log-and-re-raise expected failures. For true internal bugs, `logger.error` immediately before raising `AnalyticsInternalError` is an allowed library bug-signal at that boundary.
+Prefer raising (and wrapping with `raise ... from e` when translating errors) in the middle of the stack. Do not log-and-re-raise — neither for expected failures (e.g. insufficient privacy budget) nor for `AnalyticsInternalError`. The exception is the failure signal; applications that care about ERROR-level records should log when they catch at their boundary.
 
 #### Lint vs review
 
-Ruff enforces mechanical conventions (`LOG`, `G`, and `TID251` bans on `logging.basicConfig` / `dictConfig` / `fileConfig`, plus `loguru` / `structlog`). Level choice, log-once judgment, channel choice, and message coarseness are reviewed against this section — they are not fully lintable.
+Ruff enforces mechanical conventions (`LOG`, `G`, and `TID251` bans on `logging.basicConfig` / `dictConfig` / `fileConfig`, plus `loguru` / `structlog`). A unit test bans `logger.error` / `logger.exception` under `src/tmlt/analytics` (library call sites raise instead). Other level choice, channel choice, and message coarseness are reviewed against this section.
 
 ### Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,37 @@ Note that some operating systems, including macOS, include versions of `make` th
 
 Behind the scenes, these commands use the `uv` environment, and rely on [nox](https://nox.thea.codes/en/stable/index.html) for test automation. You can get a bit more fine-grained control and access additional tools by running nox commands directly (see [this tutorial](https://nox.thea.codes/en/stable/tutorial.html)). You can find a list of available nox sessions using `uv run nox --list`, then run one of these sessions using e.g. `uv run nox -s test-fast`.
 
+### Logging
+
+Tumult Analytics uses Python's stdlib [`logging`](https://docs.python.org/3/library/logging.html) module. Library code should use `logging.getLogger(__name__)`, never configure handlers or call `basicConfig` / `dictConfig`, and keep messages coarse (query class names and privacy-budget *types*, not ASTs, row data, or numeric remaining budgets).
+
+Helpers and a short channel summary live in [`src/tmlt/analytics/_logging.py`](./src/tmlt/analytics/_logging.py).
+
+#### Levels
+
+| Level | Use for |
+|-------|---------|
+| **DEBUG** | High-volume diagnostic detail (query compile/evaluate steps, noise mechanism summary). |
+| **INFO** | Rare, high-signal lifecycle events (e.g. Session created; log budget *type* only). |
+| **WARNING** | Recoverable or suboptimal situations that still continue (e.g. noisy Spark log level). |
+| **ERROR** | Unexpected internal failures (`AnalyticsInternalError`). Not for expected control-flow errors such as insufficient privacy budget — raise those without logging. |
+
+#### Channels
+
+- **`print`** — intentional interactive UX (`Session.describe`, `check_installation`).
+- **`warnings.warn`** — advisories that must be visible without configuring logging.
+- **`logging`** — diagnostics for operators who configure logging.
+
+Do not migrate existing `warnings.warn` call sites to `logger.warning` without considering visibility.
+
+#### Log-once vs raise
+
+Prefer raising (and wrapping with `raise ... from e` when translating errors) in the middle of the stack. Do not log-and-re-raise expected failures. For true internal bugs, `logger.error` immediately before raising `AnalyticsInternalError` is an allowed library bug-signal at that boundary.
+
+#### Lint vs review
+
+Ruff enforces mechanical conventions (`LOG`, `G`, and `TID251` bans on `logging.basicConfig` / `dictConfig` / `fileConfig`, plus `loguru` / `structlog`). Level choice, log-once judgment, channel choice, and message coarseness are reviewed against this section — they are not fully lintable.
+
 ### Testing
 
 Our unit tests are run with [pytest](https://docs.pytest.org/en/stable/getting-started.html). You can run smaller subsets of tests by using pytest directly. For example, to check tests in a particular test file, run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,26 +37,38 @@ Behind the scenes, these commands use the `uv` environment, and rely on [nox](ht
 
 ### Logging
 
-Tumult Analytics uses Python's stdlib [`logging`](https://docs.python.org/3/library/logging.html) module. Library code should use `logging.getLogger(__name__)`, never configure handlers or call `basicConfig` / `dictConfig`, and keep messages coarse (query class names and privacy-budget *types*, not ASTs, row data, or numeric remaining budgets).
+Tumult Analytics uses Python's stdlib [`logging`](https://docs.python.org/3/library/logging.html) module. Library code should use `logging.getLogger(__name__)` and never configure handlers or call `basicConfig` / `dictConfig`. Coverage is intentionally thin and will grow; these guidelines apply to new statements.
 
 Helpers and a short channel summary live in [`src/tmlt/analytics/_logging.py`](./src/tmlt/analytics/_logging.py).
+
+#### When to log (consider)
+
+- The library makes a decision that is not user-specified (e.g. picking a default mechanism).
+- A major milestone in program execution (e.g. Session creation, executing a query).
+- Bracketing a long-running or otherwise expensive operation (e.g. compiling a query or executing a Spark plan).
+
+These are considerations, not a checklist. Existing call sites are a starting pattern; this section does not require expanding them to match the list.
 
 #### Levels
 
 | Level | Use for |
 |-------|---------|
-| **DEBUG** | High-volume diagnostic detail (query compile/evaluate steps, noise mechanism summary). |
+| **DEBUG** | High-volume diagnostic detail (query compile/evaluate steps, noise mechanism summary). Budget *values* may appear here if they help operators. |
 | **INFO** | Rare, high-signal lifecycle events (e.g. Session created; log budget *type* only). |
-| **WARNING** | Recoverable or suboptimal situations that still continue (e.g. noisy Spark log level). |
+| **WARNING** | Recoverable or suboptimal situations that still continue (e.g. noisy Spark log level). Library WARNING is *not* visible by default: a `NullHandler` on `tmlt.analytics` prevents stdlib lastResort from writing to stderr. |
 | **ERROR** | Not used at Analytics call sites. Applications may log at ERROR when they catch failures at their boundary. Internal bugs use `AnalyticsInternalError` (raise only). |
+
+#### Coarseness
+
+Never log row data, query ASTs, or PII. That is a hard ban (volume and accidental leak into operator logs). Remaining privacy-budget numbers are *not* the same class: they are optional at DEBUG. Session INFO stays budget *type* only so INFO remains rare and high-signal.
+
+Coarseness is operator hygiene, not a privacy control. Logs are not covered outputs — see the [privacy promise](./doc/topic-guides/privacy-promise.rst) (Subtlety 1).
 
 #### Channels
 
 - **`print`** — intentional interactive UX (`Session.describe`, `check_installation`).
-- **`warnings.warn`** — advisories that must be visible without configuring logging.
-- **`logging`** — diagnostics for operators who configure logging (DEBUG / INFO / WARNING in this library).
-
-Do not migrate existing `warnings.warn` call sites to `logger.warning` without considering visibility.
+- **`warnings.warn`** — advisories that must be visible without configuring logging. Do not mass-migrate existing call sites to `logger.warning`.
+- **`logging`** — diagnostics (DEBUG / INFO / WARNING in this library). The Spark noisy-check dual-emits `warnings.warn` + `logger.warning` because NullHandler blocks lastResort; that exception is scoped to this setup advisory.
 
 #### Log-once vs raise
 

--- a/doc/deployment/spark.rst
+++ b/doc/deployment/spark.rst
@@ -57,12 +57,23 @@ prefer:
 
 When Analytics detects a noisy SparkContext log level (``ALL``, ``DEBUG``, or
 ``INFO``), it emits a one-time :class:`UserWarning` and a matching
-``logging`` warning. py4j can also be chatty independently of
+:mod:`logging` warning. py4j can also be chatty independently of
 ``setLogLevel``; you can quiet it with:
 
 .. code-block::
 
     logging.getLogger("py4j").setLevel(logging.ERROR)
+
+Spark console progress bars (``[Stage 0:> (0 + 1) / 1]``) are separate from
+log level. Disable them if that noise is unwanted:
+
+.. code-block::
+
+    spark = SparkSession.builder.config(
+        "spark.ui.showConsoleProgress", "false"
+    ).getOrCreate()
+    # Or, after the session exists:
+    # spark.conf.set("spark.ui.showConsoleProgress", "false")
 
 Connecting to Hive
 ^^^^^^^^^^^^^^^^^^

--- a/doc/deployment/spark.rst
+++ b/doc/deployment/spark.rst
@@ -28,6 +28,41 @@ then before running Tumult Analytics code, you should create that Spark session:
 
 As long as this session is active, Tumult Analytics will use it.
 
+Logging and quieting Spark
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _spark-logging:
+
+Tumult Analytics emits diagnostic messages via Python's built-in :mod:`logging`
+module (for example when a :class:`~tmlt.analytics.Session` is created). The
+library does not configure log handlers; enable them in your application if you
+want to see Analytics messages:
+
+.. code-block::
+
+    import logging
+    logging.basicConfig(level=logging.INFO)
+    # Or configure only Analytics:
+    # logging.getLogger("tmlt.analytics").setLevel(logging.DEBUG)
+
+Spark's own logging is separate from Python logging. If you create a Spark
+session without lowering its log level, Spark output can dominate the console
+regardless of the Analytics log level you chose. After creating a session,
+prefer:
+
+.. code-block::
+
+    from pyspark.sql import SparkSession
+    spark = SparkSession.builder.getOrCreate()
+    spark.sparkContext.setLogLevel("ERROR")
+
+When Analytics detects a noisy SparkContext log level (``ALL``, ``DEBUG``, or
+``INFO``), it emits a one-time :class:`UserWarning` and a matching
+``logging`` warning. py4j can also be chatty independently of
+``setLogLevel``; you can quiet it with:
+
+.. code-block::
+
+    logging.getLogger("py4j").setLevel(logging.ERROR)
 
 Connecting to Hive
 ^^^^^^^^^^^^^^^^^^

--- a/doc/deployment/troubleshooting.rst
+++ b/doc/deployment/troubleshooting.rst
@@ -50,6 +50,15 @@ If you are using Hive tables to read and write data, you may instead want to con
 the :ref:`Hive section <hive-tips>` of the :ref:`Spark topic guide <spark>`. For more tips
 related to Spark, see the entirety of that guide.
 
+Noisy Spark or py4j logs
+------------------------
+
+If your console is flooded with Spark or py4j messages even after configuring
+Python's :mod:`logging` for Tumult Analytics, see
+:ref:`Logging and quieting Spark <spark-logging>` in the Spark topic guide.
+``spark.sparkContext.setLogLevel("ERROR")`` and quieting the ``py4j`` logger
+usually resolve this.
+
 
 ``PicklingError`` on map queries
 --------------------------------

--- a/doc/topic-guides/privacy-promise.rst
+++ b/doc/topic-guides/privacy-promise.rst
@@ -95,6 +95,11 @@ particular, public sources and parameters like ``groupby`` information or
 clamping bounds are not protected. They can reveal private information if the
 private data is used directly to determine them.
 
+Logs are also **not** covered outputs. Messages from Python's :mod:`logging`
+module, Spark's own logging, and Analytics diagnostics are not covered by the
+privacy promise. Do not release logs to anyone who is not trusted with the
+private input data. (See also the side-channel note under Subtlety 2.)
+
 Subtlety 2: adversarial model
 -----------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,11 @@ select = [
     # one set of rules.
     "RUF", "I", "PL", "D", "F", "E", "W",
     # Also enable a subset of flake8 rules, for similar reasons to pyflakes/pycodestyle.
-    "ISC", "SLF"
+    "ISC", "SLF",
+    # Mechanical logging conventions for library code (see src/tmlt/analytics/_logging.py).
+    "LOG",  # flake8-logging
+    "G",    # flake8-logging-format
+    "TID",  # flake8-tidy-imports (banned-api)
 ]
 ignore = [
     # too-many-*: These rules are too context-dependent to be generally useful,
@@ -176,6 +180,9 @@ ignore = [
     "E721",    # type-comparison
     "D103",    # undocumented-public-function
     "PLR0124", # comparison-with-itself
+    # TID251 (banned-api) is the logging policy rule we want; TID252 would force
+    # rewriting existing relative imports in tests and is out of scope.
+    "TID252",
 ]
 
 # Ruff's RUF001-003 rules disallow certain Unicode characters that are easily
@@ -190,6 +197,13 @@ combine-as-imports = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"logging.basicConfig".msg = "Library code must not configure logging; apps/notebooks configure handlers."
+"logging.config.dictConfig".msg = "Library code must not configure logging."
+"logging.config.fileConfig".msg = "Library code must not configure logging."
+"loguru".msg = "Use stdlib logging only."
+"structlog".msg = "Use stdlib logging only."
 
 [tool.mypy]
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src"

--- a/src/tmlt/analytics/__init__.py
+++ b/src/tmlt/analytics/__init__.py
@@ -86,5 +86,7 @@ from tmlt.analytics.truncation_strategy import TruncationStrategy
 from ._version import __version__
 
 # Libraries should not configure handlers; apps/notebooks do that. A NullHandler
-# avoids "No handlers could be found" if something logs before configuration.
+# on the package logger is the stdlib library howto so this logger does not
+# rely on the root logger or lastResort:
+# https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/tmlt/analytics/__init__.py
+++ b/src/tmlt/analytics/__init__.py
@@ -38,6 +38,8 @@ and then evaluating these queries with :meth:`~.session.Session.evaluate`.
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
+import logging
+
 from tmlt.analytics._utils import AnalyticsInternalError
 from tmlt.analytics.binning_spec import BinningSpec, BinT
 from tmlt.analytics.config import Config, FeatureFlag
@@ -82,3 +84,7 @@ from tmlt.analytics.truncation_strategy import TruncationStrategy
 
 # This version file is populated during build -- do not commit it.
 from ._version import __version__
+
+# Libraries should not configure handlers; apps/notebooks do that. A NullHandler
+# avoids "No handlers could be found" if something logs before configuration.
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/tmlt/analytics/_logging.py
+++ b/src/tmlt/analytics/_logging.py
@@ -27,13 +27,14 @@ Use the right channel for the job:
 
 * ``print`` — intentional interactive UX (for example ``Session.describe`` and
   ``check_installation``).
-* ``warnings.warn`` — user-facing behavioral or setup advisories that must be
-  visible without configuring logging.
-* ``logging`` — diagnostic / lifecycle messages for operators who configure
-  logging.
+* ``warnings.warn`` — advisories that must be visible without configuring
+  logging (the package ``NullHandler`` prevents stdlib lastResort from
+  emitting library WARNING to stderr).
+* ``logging`` — diagnostic / lifecycle messages (DEBUG / INFO / WARNING).
 
-Keep log messages coarse: prefer query class names and privacy-budget
-*types* over full query ASTs, row data, or numeric remaining budgets.
+Never log row data, query ASTs, or PII. Coarseness is operator hygiene, not a
+privacy control. Budget *values* may appear at DEBUG; Session INFO stays
+budget *type* only.
 
 Lint vs review
 --------------
@@ -86,16 +87,18 @@ def _reset_spark_logging_warning_for_tests() -> None:
 def warn_if_spark_logging_noisy(spark: Optional[SparkSession] = None) -> None:
     """Warn once if Spark's built-in logging looks noisy.
 
-    Uses only an existing Spark session: the optional ``spark`` argument, or
+    Uses only an existing Spark session: the optional ``spark`` argument
+    (usually omitted; a test/injection seam), or
     :meth:`SparkSession.getActiveSession`. Never calls ``getOrCreate()``.
 
-    Emits both a :class:`UserWarning` (visible by default) and a
-    ``logger.warning`` (for configured log pipelines). This dual emit is
-    intentional and scoped to this setup advisory only.
+    Emits a :class:`UserWarning` (visible without logging config) and a
+    matching ``logger.warning`` (for configured log pipelines). Dual-emit is
+    scoped to this setup advisory: a ``NullHandler`` on ``tmlt.analytics``
+    means lastResort does not print library WARNING to stderr.
 
     Args:
-        spark: Session to inspect. If omitted, the active session is used when
-            one exists.
+        spark: Session to inspect. Usually omitted; the active session is used
+            when one exists.
     """
     global _spark_noise_warned  # noqa: PLW0603
     if _spark_noise_warned:

--- a/src/tmlt/analytics/_logging.py
+++ b/src/tmlt/analytics/_logging.py
@@ -55,7 +55,6 @@ from __future__ import annotations
 
 import logging
 import warnings
-from typing import Optional
 
 from pyspark.sql import SparkSession
 
@@ -84,28 +83,22 @@ def _reset_spark_logging_warning_for_tests() -> None:
     _spark_noise_warned = False
 
 
-def warn_if_spark_logging_noisy(spark: Optional[SparkSession] = None) -> None:
+def warn_if_spark_logging_noisy() -> None:
     """Warn once if Spark's built-in logging looks noisy.
 
-    Uses only an existing Spark session: the optional ``spark`` argument
-    (usually omitted; a test/injection seam), or
-    :meth:`SparkSession.getActiveSession`. Never calls ``getOrCreate()``.
+    Uses :meth:`SparkSession.getActiveSession` only. Never calls
+    ``getOrCreate()``.
 
     Emits a :class:`UserWarning` (visible without logging config) and a
     matching ``logger.warning`` (for configured log pipelines). Dual-emit is
     scoped to this setup advisory: a ``NullHandler`` on ``tmlt.analytics``
     means lastResort does not print library WARNING to stderr.
-
-    Args:
-        spark: Session to inspect. Usually omitted; the active session is used
-            when one exists.
     """
     global _spark_noise_warned  # noqa: PLW0603
     if _spark_noise_warned:
         return
 
-    if spark is None:
-        spark = SparkSession.getActiveSession()
+    spark = SparkSession.getActiveSession()
     if spark is None:
         return
 

--- a/src/tmlt/analytics/_logging.py
+++ b/src/tmlt/analytics/_logging.py
@@ -40,10 +40,11 @@ Lint vs review
 
 Ruff enforces *mechanical* conventions in CI (``LOG``, ``G``, and ``TID251``
 banned-api for ``logging.basicConfig`` / ``dictConfig`` / ``fileConfig``, plus
-``loguru`` / ``structlog``). Judgment calls — which level to use, log-once vs
-raise/wrap, channel choice (``print`` / ``warnings`` / ``logging``), and message
-coarseness — are documented in ``CONTRIBUTING.md`` and reviewed in PRs; they are
-not lintable.
+``loguru`` / ``structlog``). A unit test bans ``logger.error`` /
+``logger.exception`` under ``src/tmlt/analytics`` so failure stays raise-only.
+Other judgment calls — which of DEBUG/INFO/WARNING to use, channel choice
+(``print`` / ``warnings`` / ``logging``), and message coarseness — are
+documented in ``CONTRIBUTING.md`` and reviewed in PRs.
 """
 
 # SPDX-License-Identifier: Apache-2.0

--- a/src/tmlt/analytics/_logging.py
+++ b/src/tmlt/analytics/_logging.py
@@ -16,6 +16,10 @@ should configure logging themselves (for example with
 ``logging.basicConfig(level=logging.INFO)`` or a logger-specific handler on
 ``tmlt.analytics``).
 
+Contributor guidelines for levels, channels, and log-once behavior live in
+``CONTRIBUTING.md`` (Logging section). This module documents the same channel
+rules briefly for discoverability next to the helpers.
+
 Output channels
 ---------------
 
@@ -30,6 +34,16 @@ Use the right channel for the job:
 
 Keep log messages coarse: prefer query class names and privacy-budget
 *types* over full query ASTs, row data, or numeric remaining budgets.
+
+Lint vs review
+--------------
+
+Ruff enforces *mechanical* conventions in CI (``LOG``, ``G``, and ``TID251``
+banned-api for ``logging.basicConfig`` / ``dictConfig`` / ``fileConfig``, plus
+``loguru`` / ``structlog``). Judgment calls — which level to use, log-once vs
+raise/wrap, channel choice (``print`` / ``warnings`` / ``logging``), and message
+coarseness — are documented in ``CONTRIBUTING.md`` and reviewed in PRs; they are
+not lintable.
 """
 
 # SPDX-License-Identifier: Apache-2.0
@@ -46,8 +60,11 @@ from pyspark.sql import SparkSession
 logger = logging.getLogger(__name__)
 
 _NOISY_SPARK_LOG_LEVELS = frozenset({"ALL", "DEBUG", "INFO"})
-# Mutable container avoids a ``global`` statement for the once-per-process flag.
-_spark_noise_warned = [False]
+_spark_noise_warned = False
+
+_SPARK_DOCS_URL = (
+    "https://docs.tmlt.dev/analytics/latest/deployment/spark.html#spark-logging"
+)
 
 _SPARK_NOISE_MESSAGE = (
     "The active SparkSession has SparkContext log level {level!r}. "
@@ -55,13 +72,14 @@ _SPARK_NOISE_MESSAGE = (
     "Analytics log levels will not quiet Spark output. Consider calling "
     "spark.sparkContext.setLogLevel('ERROR') after creating the session. "
     "py4j and log4j can also produce noise independently; see the Spark "
-    "deployment guide for details."
+    f"deployment guide for details: {_SPARK_DOCS_URL}"
 )
 
 
-def reset_spark_logging_warning_for_tests() -> None:
+def _reset_spark_logging_warning_for_tests() -> None:
     """Reset the once-per-process Spark noise warning (for unit tests only)."""
-    _spark_noise_warned[0] = False
+    global _spark_noise_warned  # noqa: PLW0603
+    _spark_noise_warned = False
 
 
 def warn_if_spark_logging_noisy(spark: Optional[SparkSession] = None) -> None:
@@ -78,7 +96,8 @@ def warn_if_spark_logging_noisy(spark: Optional[SparkSession] = None) -> None:
         spark: Session to inspect. If omitted, the active session is used when
             one exists.
     """
-    if _spark_noise_warned[0]:
+    global _spark_noise_warned  # noqa: PLW0603
+    if _spark_noise_warned:
         return
 
     if spark is None:
@@ -87,7 +106,11 @@ def warn_if_spark_logging_noisy(spark: Optional[SparkSession] = None) -> None:
         return
 
     try:
-        level = spark.sparkContext.getLogLevel()
+        # PySpark exposes getLogLevel at runtime; stubs often omit it.
+        get_log_level = getattr(spark.sparkContext, "getLogLevel", None)
+        if not callable(get_log_level):
+            return
+        level = get_log_level()
     except Exception:
         # Never fail Session creation because Spark logging could not be inspected.
         return
@@ -102,4 +125,4 @@ def warn_if_spark_logging_noisy(spark: Optional[SparkSession] = None) -> None:
     message = _SPARK_NOISE_MESSAGE.format(level=level_name)
     warnings.warn(message, UserWarning, stacklevel=2)
     logger.warning(message)
-    _spark_noise_warned[0] = True
+    _spark_noise_warned = True

--- a/src/tmlt/analytics/_logging.py
+++ b/src/tmlt/analytics/_logging.py
@@ -1,0 +1,105 @@
+"""Logging helpers and contributor guidance for Tumult Analytics.
+
+Tumult Analytics uses the standard-library :mod:`logging` module. Library code
+should follow this pattern:
+
+.. code-block:: python
+
+    import logging
+
+    logger = logging.getLogger(__name__)
+    logger.info("...")
+
+The library does **not** configure the root logger, handlers, formatters, or
+levels. Applications and notebooks that want to see Analytics log messages
+should configure logging themselves (for example with
+``logging.basicConfig(level=logging.INFO)`` or a logger-specific handler on
+``tmlt.analytics``).
+
+Output channels
+---------------
+
+Use the right channel for the job:
+
+* ``print`` — intentional interactive UX (for example ``Session.describe`` and
+  ``check_installation``).
+* ``warnings.warn`` — user-facing behavioral or setup advisories that must be
+  visible without configuring logging.
+* ``logging`` — diagnostic / lifecycle messages for operators who configure
+  logging.
+
+Keep log messages coarse: prefer query class names and privacy-budget
+*types* over full query ASTs, row data, or numeric remaining budgets.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Tumult Labs 2025
+
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import Optional
+
+from pyspark.sql import SparkSession
+
+logger = logging.getLogger(__name__)
+
+_NOISY_SPARK_LOG_LEVELS = frozenset({"ALL", "DEBUG", "INFO"})
+# Mutable container avoids a ``global`` statement for the once-per-process flag.
+_spark_noise_warned = [False]
+
+_SPARK_NOISE_MESSAGE = (
+    "The active SparkSession has SparkContext log level {level!r}. "
+    "Spark's own logging is separate from Python's logging module, so "
+    "Analytics log levels will not quiet Spark output. Consider calling "
+    "spark.sparkContext.setLogLevel('ERROR') after creating the session. "
+    "py4j and log4j can also produce noise independently; see the Spark "
+    "deployment guide for details."
+)
+
+
+def reset_spark_logging_warning_for_tests() -> None:
+    """Reset the once-per-process Spark noise warning (for unit tests only)."""
+    _spark_noise_warned[0] = False
+
+
+def warn_if_spark_logging_noisy(spark: Optional[SparkSession] = None) -> None:
+    """Warn once if Spark's built-in logging looks noisy.
+
+    Uses only an existing Spark session: the optional ``spark`` argument, or
+    :meth:`SparkSession.getActiveSession`. Never calls ``getOrCreate()``.
+
+    Emits both a :class:`UserWarning` (visible by default) and a
+    ``logger.warning`` (for configured log pipelines). This dual emit is
+    intentional and scoped to this setup advisory only.
+
+    Args:
+        spark: Session to inspect. If omitted, the active session is used when
+            one exists.
+    """
+    if _spark_noise_warned[0]:
+        return
+
+    if spark is None:
+        spark = SparkSession.getActiveSession()
+    if spark is None:
+        return
+
+    try:
+        level = spark.sparkContext.getLogLevel()
+    except Exception:
+        # Never fail Session creation because Spark logging could not be inspected.
+        return
+
+    if level is None:
+        return
+
+    level_name = str(level).upper()
+    if level_name not in _NOISY_SPARK_LOG_LEVELS:
+        return
+
+    message = _SPARK_NOISE_MESSAGE.format(level=level_name)
+    warnings.warn(message, UserWarning, stacklevel=2)
+    logger.warning(message)
+    _spark_noise_warned[0] = True

--- a/src/tmlt/analytics/_query_expr_compiler/_compiler.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_compiler.py
@@ -181,12 +181,10 @@ class QueryExprCompiler:
                 measurement.privacy_function(stability) != visitor.adjusted_budget.value
             )
         if privacy_function_budget_mismatch:
-            message = (
+            raise AnalyticsInternalError(
                 "Query measurement privacy function does not match "
                 "privacy budget value."
             )
-            logger.error(message)
-            raise AnalyticsInternalError(message)
 
         return measurement, noise_info
 

--- a/src/tmlt/analytics/_query_expr_compiler/_compiler.py
+++ b/src/tmlt/analytics/_query_expr_compiler/_compiler.py
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
+import logging
 from typing import Any, List, Tuple, Union
 
 from tmlt.core.domains.collections import DictDomain
@@ -29,6 +30,8 @@ from tmlt.analytics._schema import Schema
 from tmlt.analytics._table_reference import TableReference
 from tmlt.analytics.constraints import Constraint
 from tmlt.analytics.privacy_budget import PrivacyBudget
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_MECHANISM = "DEFAULT"
 """Constant used for DEFAULT noise mechanism"""
@@ -135,6 +138,7 @@ class QueryExprCompiler:
         query.schema(catalog)
 
         # Compilation happens in two stages: first, we apply rewrite rules...
+        logger.debug("Rewriting query of type %s", type(query).__name__)
         compilation_info = CompilationInfo(
             output_measure=self._output_measure,
             catalog=catalog,
@@ -156,6 +160,13 @@ class QueryExprCompiler:
         if not isinstance(measurement, Measurement):
             raise AnalyticsInternalError("This query did not create a measurement.")
 
+        mechanisms = [info.get("noise_mechanism") for info in noise_info]
+        logger.debug(
+            "Compiled query of type %s; noise mechanisms: %s",
+            type(query).__name__,
+            mechanisms,
+        )
+
         if isinstance(visitor.adjusted_budget.value, tuple):
             # TODO(#2754): add a log message.
             privacy_function_budget_mismatch = any(
@@ -170,10 +181,12 @@ class QueryExprCompiler:
                 measurement.privacy_function(stability) != visitor.adjusted_budget.value
             )
         if privacy_function_budget_mismatch:
-            raise AnalyticsInternalError(
+            message = (
                 "Query measurement privacy function does not match "
                 "privacy budget value."
             )
+            logger.error(message)
+            raise AnalyticsInternalError(message)
 
         return measurement, noise_info
 

--- a/src/tmlt/analytics/session.py
+++ b/src/tmlt/analytics/session.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
+import logging
 from operator import xor
 from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
 from warnings import warn
@@ -49,6 +50,7 @@ from tmlt.analytics._base_builder import (
 )
 from tmlt.analytics._catalog import Catalog
 from tmlt.analytics._coerce_spark_schema import coerce_spark_schema_or_fail
+from tmlt.analytics._logging import warn_if_spark_logging_noisy
 from tmlt.analytics._neighboring_relation import (
     AddRemoveKeys,
     AddRemoveRows,
@@ -106,6 +108,8 @@ from tmlt.analytics.query_builder import (
     Query,
     QueryBuilder,
 )
+
+logger = logging.getLogger(__name__)
 
 __all__ = ["Session"]
 
@@ -292,6 +296,11 @@ class Session:
             for source_id, dataframe in self._public_dataframes.items():
                 sess.add_public_dataframe(source_id, dataframe)
 
+            logger.info(
+                "Created Session with privacy budget type %s",
+                type(self._privacy_budget).__name__,
+            )
+            warn_if_spark_logging_noisy()
             return sess
 
     def __init__(
@@ -1105,6 +1114,7 @@ class Session:
         """
         check_type(query_expr, Query)
         query = query_expr._query_expr
+        logger.debug("Evaluating query of type %s", type(query).__name__)
         measurement, adjusted_budget, _ = self._compile_and_get_info(
             query, privacy_budget
         )
@@ -1114,24 +1124,32 @@ class Session:
             isinstance(self._accountant.privacy_budget, tuple),
             isinstance(adjusted_budget.value, tuple),
         ):
-            raise AnalyticsInternalError(
+            message = (
                 "Expected type of adjusted_budget to match type of accountant's privacy"
                 f" budget ({type(self._accountant.privacy_budget)}), but instead"
                 f" received {type(adjusted_budget.value)}."
             )
+            logger.error(message)
+            raise AnalyticsInternalError(message)
 
         try:
             if not measurement.privacy_relation(
                 self._accountant.d_in, adjusted_budget.value
             ):
-                raise AnalyticsInternalError(
+                message = (
                     "With these inputs and this privacy budget, similar inputs will"
                     " *not* produce similar outputs."
                 )
+                logger.error(message)
+                raise AnalyticsInternalError(message)
             try:
-                return self._accountant.measure(
+                result = self._accountant.measure(
                     measurement, d_out=adjusted_budget.value
                 )
+                logger.debug(
+                    "Finished evaluating query of type %s", type(query).__name__
+                )
+                return result
             except InsufficientBudgetError as err:
                 msg = _format_insufficient_budget_msg(
                     err.requested_budget.value,

--- a/src/tmlt/analytics/session.py
+++ b/src/tmlt/analytics/session.py
@@ -1129,19 +1129,16 @@ class Session:
                 f" budget ({type(self._accountant.privacy_budget)}), but instead"
                 f" received {type(adjusted_budget.value)}."
             )
-            logger.error(message)
             raise AnalyticsInternalError(message)
 
         try:
             if not measurement.privacy_relation(
                 self._accountant.d_in, adjusted_budget.value
             ):
-                message = (
+                raise AnalyticsInternalError(
                     "With these inputs and this privacy budget, similar inputs will"
                     " *not* produce similar outputs."
                 )
-                logger.error(message)
-                raise AnalyticsInternalError(message)
             try:
                 result = self._accountant.measure(
                     measurement, d_out=adjusted_budget.value

--- a/src/tmlt/analytics/session.py
+++ b/src/tmlt/analytics/session.py
@@ -1124,12 +1124,11 @@ class Session:
             isinstance(self._accountant.privacy_budget, tuple),
             isinstance(adjusted_budget.value, tuple),
         ):
-            message = (
+            raise AnalyticsInternalError(
                 "Expected type of adjusted_budget to match type of accountant's privacy"
                 f" budget ({type(self._accountant.privacy_budget)}), but instead"
                 f" received {type(adjusted_budget.value)}."
             )
-            raise AnalyticsInternalError(message)
 
         try:
             if not measurement.privacy_relation(

--- a/test/unit/test_logging.py
+++ b/test/unit/test_logging.py
@@ -30,8 +30,10 @@ def _reset_spark_warning():
 
 
 @pytest.fixture
-def mock_spark(request: pytest.FixtureRequest) -> MagicMock:
-    """Spark session mock with a configurable SparkContext log level.
+def mock_spark(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> MagicMock:
+    """Spark session mock installed as the active session.
 
     Parametrize with ``@pytest.mark.parametrize("mock_spark", [...], indirect=True)``.
     Defaults to ``"INFO"`` when not parametrized.
@@ -39,6 +41,9 @@ def mock_spark(request: pytest.FixtureRequest) -> MagicMock:
     log_level = getattr(request, "param", "INFO")
     spark = MagicMock()
     spark.sparkContext.getLogLevel.return_value = log_level
+    monkeypatch.setattr(
+        "tmlt.analytics._logging.SparkSession.getActiveSession", lambda: spark
+    )
     return spark
 
 
@@ -49,13 +54,13 @@ def test_warn_if_spark_logging_noisy_warns_once(
     """Noisy Spark levels trigger UserWarning and logger.warning once."""
     with caplog.at_level(logging.WARNING, logger="tmlt.analytics._logging"):
         with pytest.warns(UserWarning, match="setLogLevel"):
-            warn_if_spark_logging_noisy(mock_spark)
+            warn_if_spark_logging_noisy()
         assert any("setLogLevel" in r.message for r in caplog.records)
         assert any("docs.tmlt.dev" in r.message for r in caplog.records)
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            warn_if_spark_logging_noisy(mock_spark)
+            warn_if_spark_logging_noisy()
             assert caught == []
         assert sum(1 for r in caplog.records if "setLogLevel" in r.message) == 1
 
@@ -72,7 +77,7 @@ def test_warn_if_spark_logging_noisy_quiet_levels(
     with caplog.at_level(logging.WARNING, logger="tmlt.analytics._logging"):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            warn_if_spark_logging_noisy(mock_spark)
+            warn_if_spark_logging_noisy()
             assert caught == []
         assert caplog.records == []
 
@@ -80,7 +85,7 @@ def test_warn_if_spark_logging_noisy_quiet_levels(
 def test_warn_if_spark_logging_noisy_noop_without_session(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """No active session and no argument means no warning."""
+    """No active session means no warning."""
     monkeypatch.setattr(
         "tmlt.analytics._logging.SparkSession.getActiveSession", lambda: None
     )
@@ -93,15 +98,19 @@ def test_warn_if_spark_logging_noisy_noop_without_session(
 
 
 def test_warn_if_spark_logging_noisy_swallows_get_log_level_errors(
+    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Failures inspecting Spark log level must not propagate."""
     spark = MagicMock()
     spark.sparkContext.getLogLevel.side_effect = RuntimeError("unavailable")
+    monkeypatch.setattr(
+        "tmlt.analytics._logging.SparkSession.getActiveSession", lambda: spark
+    )
     with caplog.at_level(logging.WARNING, logger="tmlt.analytics._logging"):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            warn_if_spark_logging_noisy(spark)
+            warn_if_spark_logging_noisy()
             assert caught == []
         assert caplog.records == []
 

--- a/test/unit/test_logging.py
+++ b/test/unit/test_logging.py
@@ -3,8 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Tumult Labs 2025
 
+from __future__ import annotations
+
+import ast
 import logging
 import warnings
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,6 +17,9 @@ from tmlt.analytics._logging import (
     _reset_spark_logging_warning_for_tests,
     warn_if_spark_logging_noisy,
 )
+
+_ANALYTICS_SRC = Path(__file__).resolve().parents[2] / "src" / "tmlt" / "analytics"
+_BANNED_LOG_METHODS = frozenset({"error", "exception"})
 
 
 @pytest.fixture(autouse=True)
@@ -98,3 +105,33 @@ def test_warn_if_spark_logging_noisy_swallows_get_log_level_errors(
             warn_if_spark_logging_noisy(spark)
             assert caught == []
         assert caplog.records == []
+
+
+def test_no_library_error_level_logging() -> None:
+    """Library call sites must not use logger.error / logger.exception.
+
+    Failures are signaled by raising (see CONTRIBUTING.md Logging). Applications
+    may log at ERROR when they catch at their boundary.
+    """
+    violations: list[str] = []
+    for path in sorted(_ANALYTICS_SRC.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute):
+                continue
+            if func.attr not in _BANNED_LOG_METHODS:
+                continue
+            # Match logger.error(...) / logging.error(...) style call sites.
+            if isinstance(func.value, ast.Name) and func.value.id in {
+                "logger",
+                "logging",
+            }:
+                rel = path.relative_to(_ANALYTICS_SRC.parent.parent.parent)
+                violations.append(f"{rel}:{node.lineno}: {func.value.id}.{func.attr}")
+    assert violations == [], (
+        "ERROR-level logging is banned in tmlt.analytics; raise instead:\n"
+        + "\n".join(violations)
+    )

--- a/test/unit/test_logging.py
+++ b/test/unit/test_logging.py
@@ -53,7 +53,6 @@ def test_warn_if_spark_logging_noisy_warns_once(
         assert any("setLogLevel" in r.message for r in caplog.records)
         assert any("docs.tmlt.dev" in r.message for r in caplog.records)
 
-        # Second call should be a no-op.
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             warn_if_spark_logging_noisy(mock_spark)

--- a/test/unit/test_logging.py
+++ b/test/unit/test_logging.py
@@ -9,65 +9,71 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tmlt.analytics import AddOneRow, PureDPBudget, Session
-from tmlt.analytics._base_builder import PrivateDataFrame
 from tmlt.analytics._logging import (
-    reset_spark_logging_warning_for_tests,
+    _reset_spark_logging_warning_for_tests,
     warn_if_spark_logging_noisy,
 )
-from tmlt.analytics._neighboring_relation import AddRemoveRows, Conjunction
 
 
 @pytest.fixture(autouse=True)
 def _reset_spark_warning():
-    reset_spark_logging_warning_for_tests()
+    _reset_spark_logging_warning_for_tests()
     yield
-    reset_spark_logging_warning_for_tests()
+    _reset_spark_logging_warning_for_tests()
 
 
-def _mock_spark(log_level: str) -> MagicMock:
+@pytest.fixture
+def mock_spark(request: pytest.FixtureRequest) -> MagicMock:
+    """Spark session mock with a configurable SparkContext log level.
+
+    Parametrize with ``@pytest.mark.parametrize("mock_spark", [...], indirect=True)``.
+    Defaults to ``"INFO"`` when not parametrized.
+    """
+    log_level = getattr(request, "param", "INFO")
     spark = MagicMock()
     spark.sparkContext.getLogLevel.return_value = log_level
     return spark
 
 
-def test_warn_if_spark_logging_noisy_warns_on_info(caplog) -> None:
-    """INFO Spark log level triggers UserWarning and logger.warning once."""
-    spark = _mock_spark("INFO")
+@pytest.mark.parametrize("mock_spark", ["ALL", "DEBUG", "INFO", "info"], indirect=True)
+def test_warn_if_spark_logging_noisy_warns_once(
+    mock_spark: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Noisy Spark levels trigger UserWarning and logger.warning once."""
     with caplog.at_level(logging.WARNING, logger="tmlt.analytics._logging"):
         with pytest.warns(UserWarning, match="setLogLevel"):
-            warn_if_spark_logging_noisy(spark)
+            warn_if_spark_logging_noisy(mock_spark)
         assert any("setLogLevel" in r.message for r in caplog.records)
+        assert any("docs.tmlt.dev" in r.message for r in caplog.records)
 
         # Second call should be a no-op.
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            warn_if_spark_logging_noisy(spark)
+            warn_if_spark_logging_noisy(mock_spark)
             assert caught == []
         assert sum(1 for r in caplog.records if "setLogLevel" in r.message) == 1
 
 
-@pytest.mark.parametrize("level", ["ERROR", "FATAL", "OFF", "WARN", "WARNING"])
-def test_warn_if_spark_logging_noisy_quiet_levels(level: str, caplog) -> None:
+@pytest.mark.parametrize(
+    "mock_spark",
+    ["ERROR", "FATAL", "OFF", "WARN", "WARNING"],
+    indirect=True,
+)
+def test_warn_if_spark_logging_noisy_quiet_levels(
+    mock_spark: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
     """Non-noisy Spark log levels do not warn."""
-    spark = _mock_spark(level)
     with caplog.at_level(logging.WARNING, logger="tmlt.analytics._logging"):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            warn_if_spark_logging_noisy(spark)
+            warn_if_spark_logging_noisy(mock_spark)
             assert caught == []
         assert caplog.records == []
 
 
-@pytest.mark.parametrize("level", ["ALL", "DEBUG", "info"])
-def test_warn_if_spark_logging_noisy_noisy_levels(level: str) -> None:
-    """ALL/DEBUG/INFO (case-insensitive) trigger the advisory."""
-    spark = _mock_spark(level)
-    with pytest.warns(UserWarning, match="SparkContext log level"):
-        warn_if_spark_logging_noisy(spark)
-
-
-def test_warn_if_spark_logging_noisy_noop_without_session(monkeypatch, caplog) -> None:
+def test_warn_if_spark_logging_noisy_noop_without_session(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """No active session and no argument means no warning."""
     monkeypatch.setattr(
         "tmlt.analytics._logging.SparkSession.getActiveSession", lambda: None
@@ -80,7 +86,9 @@ def test_warn_if_spark_logging_noisy_noop_without_session(monkeypatch, caplog) -
         assert caplog.records == []
 
 
-def test_warn_if_spark_logging_noisy_swallows_get_log_level_errors(caplog) -> None:
+def test_warn_if_spark_logging_noisy_swallows_get_log_level_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Failures inspecting Spark log level must not propagate."""
     spark = MagicMock()
     spark.sparkContext.getLogLevel.side_effect = RuntimeError("unavailable")
@@ -90,72 +98,3 @@ def test_warn_if_spark_logging_noisy_swallows_get_log_level_errors(caplog) -> No
             warn_if_spark_logging_noisy(spark)
             assert caught == []
         assert caplog.records == []
-
-
-def test_session_build_logs_info(caplog, monkeypatch) -> None:
-    """Session.Builder.build logs an INFO message with the budget type."""
-    mock_sess = MagicMock()
-    monkeypatch.setattr(
-        Session,
-        "_from_neighboring_relation",
-        classmethod(lambda cls, *args, **kwargs: mock_sess),
-    )
-    monkeypatch.setattr(
-        "tmlt.analytics.session._generate_neighboring_relation",
-        lambda sources: Conjunction(AddRemoveRows("data", 1)),
-    )
-    monkeypatch.setattr(
-        "tmlt.analytics.session.warn_if_spark_logging_noisy", lambda: None
-    )
-
-    builder = Session.Builder().with_privacy_budget(PureDPBudget(1))
-    builder._DataFrameMixin__private_dataframes["data"] = PrivateDataFrame(
-        dataframe=MagicMock(), protected_change=AddOneRow()
-    )
-
-    with caplog.at_level(logging.INFO, logger="tmlt.analytics.session"):
-        result = builder.build()
-
-    assert result is mock_sess
-    assert any(
-        "Created Session with privacy budget type PureDPBudget" in r.message
-        for r in caplog.records
-    )
-
-
-def test_evaluate_logs_debug(caplog, monkeypatch) -> None:
-    """Session.evaluate logs DEBUG start/finish messages."""
-    sess = Session.__new__(Session)
-    sess._accountant = MagicMock()
-    sess._accountant.privacy_budget = object()
-    sess._accountant.d_in = object()
-    sess._accountant.measure.return_value = "answer"
-    sess._activate_accountant = MagicMock()  # type: ignore[method-assign]
-
-    query = type("GroupByCount", (), {})()
-    query_wrapper = MagicMock()
-    query_wrapper._query_expr = query
-
-    measurement = MagicMock()
-    measurement.privacy_relation.return_value = True
-    adjusted_budget = MagicMock()
-    adjusted_budget.value = object()
-
-    monkeypatch.setattr(
-        sess,
-        "_compile_and_get_info",
-        lambda *args, **kwargs: (measurement, adjusted_budget, None),
-    )
-    monkeypatch.setattr(
-        "tmlt.analytics.session.check_type", lambda *args, **kwargs: None
-    )
-
-    with caplog.at_level(logging.DEBUG, logger="tmlt.analytics.session"):
-        result = sess.evaluate(query_wrapper, PureDPBudget(0.5))
-
-    assert result == "answer"
-    messages = [r.message for r in caplog.records]
-    assert any(m.startswith("Evaluating query of type GroupByCount") for m in messages)
-    assert any(
-        m.startswith("Finished evaluating query of type GroupByCount") for m in messages
-    )

--- a/test/unit/test_logging.py
+++ b/test/unit/test_logging.py
@@ -1,0 +1,161 @@
+"""Unit tests for :mod:`tmlt.analytics._logging`."""
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Tumult Labs 2025
+
+import logging
+import warnings
+from unittest.mock import MagicMock
+
+import pytest
+
+from tmlt.analytics import AddOneRow, PureDPBudget, Session
+from tmlt.analytics._base_builder import PrivateDataFrame
+from tmlt.analytics._logging import (
+    reset_spark_logging_warning_for_tests,
+    warn_if_spark_logging_noisy,
+)
+from tmlt.analytics._neighboring_relation import AddRemoveRows, Conjunction
+
+
+@pytest.fixture(autouse=True)
+def _reset_spark_warning():
+    reset_spark_logging_warning_for_tests()
+    yield
+    reset_spark_logging_warning_for_tests()
+
+
+def _mock_spark(log_level: str) -> MagicMock:
+    spark = MagicMock()
+    spark.sparkContext.getLogLevel.return_value = log_level
+    return spark
+
+
+def test_warn_if_spark_logging_noisy_warns_on_info(caplog) -> None:
+    """INFO Spark log level triggers UserWarning and logger.warning once."""
+    spark = _mock_spark("INFO")
+    with caplog.at_level(logging.WARNING, logger="tmlt.analytics._logging"):
+        with pytest.warns(UserWarning, match="setLogLevel"):
+            warn_if_spark_logging_noisy(spark)
+        assert any("setLogLevel" in r.message for r in caplog.records)
+
+        # Second call should be a no-op.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warn_if_spark_logging_noisy(spark)
+            assert caught == []
+        assert sum(1 for r in caplog.records if "setLogLevel" in r.message) == 1
+
+
+@pytest.mark.parametrize("level", ["ERROR", "FATAL", "OFF", "WARN", "WARNING"])
+def test_warn_if_spark_logging_noisy_quiet_levels(level: str, caplog) -> None:
+    """Non-noisy Spark log levels do not warn."""
+    spark = _mock_spark(level)
+    with caplog.at_level(logging.WARNING, logger="tmlt.analytics._logging"):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warn_if_spark_logging_noisy(spark)
+            assert caught == []
+        assert caplog.records == []
+
+
+@pytest.mark.parametrize("level", ["ALL", "DEBUG", "info"])
+def test_warn_if_spark_logging_noisy_noisy_levels(level: str) -> None:
+    """ALL/DEBUG/INFO (case-insensitive) trigger the advisory."""
+    spark = _mock_spark(level)
+    with pytest.warns(UserWarning, match="SparkContext log level"):
+        warn_if_spark_logging_noisy(spark)
+
+
+def test_warn_if_spark_logging_noisy_noop_without_session(monkeypatch, caplog) -> None:
+    """No active session and no argument means no warning."""
+    monkeypatch.setattr(
+        "tmlt.analytics._logging.SparkSession.getActiveSession", lambda: None
+    )
+    with caplog.at_level(logging.WARNING, logger="tmlt.analytics._logging"):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warn_if_spark_logging_noisy()
+            assert caught == []
+        assert caplog.records == []
+
+
+def test_warn_if_spark_logging_noisy_swallows_get_log_level_errors(caplog) -> None:
+    """Failures inspecting Spark log level must not propagate."""
+    spark = MagicMock()
+    spark.sparkContext.getLogLevel.side_effect = RuntimeError("unavailable")
+    with caplog.at_level(logging.WARNING, logger="tmlt.analytics._logging"):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            warn_if_spark_logging_noisy(spark)
+            assert caught == []
+        assert caplog.records == []
+
+
+def test_session_build_logs_info(caplog, monkeypatch) -> None:
+    """Session.Builder.build logs an INFO message with the budget type."""
+    mock_sess = MagicMock()
+    monkeypatch.setattr(
+        Session,
+        "_from_neighboring_relation",
+        classmethod(lambda cls, *args, **kwargs: mock_sess),
+    )
+    monkeypatch.setattr(
+        "tmlt.analytics.session._generate_neighboring_relation",
+        lambda sources: Conjunction(AddRemoveRows("data", 1)),
+    )
+    monkeypatch.setattr(
+        "tmlt.analytics.session.warn_if_spark_logging_noisy", lambda: None
+    )
+
+    builder = Session.Builder().with_privacy_budget(PureDPBudget(1))
+    builder._DataFrameMixin__private_dataframes["data"] = PrivateDataFrame(
+        dataframe=MagicMock(), protected_change=AddOneRow()
+    )
+
+    with caplog.at_level(logging.INFO, logger="tmlt.analytics.session"):
+        result = builder.build()
+
+    assert result is mock_sess
+    assert any(
+        "Created Session with privacy budget type PureDPBudget" in r.message
+        for r in caplog.records
+    )
+
+
+def test_evaluate_logs_debug(caplog, monkeypatch) -> None:
+    """Session.evaluate logs DEBUG start/finish messages."""
+    sess = Session.__new__(Session)
+    sess._accountant = MagicMock()
+    sess._accountant.privacy_budget = object()
+    sess._accountant.d_in = object()
+    sess._accountant.measure.return_value = "answer"
+    sess._activate_accountant = MagicMock()  # type: ignore[method-assign]
+
+    query = type("GroupByCount", (), {})()
+    query_wrapper = MagicMock()
+    query_wrapper._query_expr = query
+
+    measurement = MagicMock()
+    measurement.privacy_relation.return_value = True
+    adjusted_budget = MagicMock()
+    adjusted_budget.value = object()
+
+    monkeypatch.setattr(
+        sess,
+        "_compile_and_get_info",
+        lambda *args, **kwargs: (measurement, adjusted_budget, None),
+    )
+    monkeypatch.setattr(
+        "tmlt.analytics.session.check_type", lambda *args, **kwargs: None
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="tmlt.analytics.session"):
+        result = sess.evaluate(query_wrapper, PureDPBudget(0.5))
+
+    assert result == "answer"
+    messages = [r.message for r in caplog.records]
+    assert any(m.startswith("Evaluating query of type GroupByCount") for m in messages)
+    assert any(
+        m.startswith("Finished evaluating query of type GroupByCount") for m in messages
+    )


### PR DESCRIPTION
Establish a library-friendly logging pattern and Spark noise advisory so operators can enable diagnostics without the library configuring handlers.