### PR TITLE
fix: prevent delete_view from deleting base private tables

### DIFF
--- a/src/tmlt/analytics/session.py
+++ b/src/tmlt/analytics/session.py
@@ -330,6 +330,7 @@ class Session:
         self._table_constraints: Dict[Identifier, List[Constraint]] = {
             NamedTable(t): [] for t in self.private_sources
         }
+        self._base_private_sources: List[str] = list(self.private_sources)
 
     @classmethod
     @typechecked
@@ -1252,6 +1253,12 @@ class Session:
             source_id: The name of the view.
         """
         self._activate_accountant()
+
+        if source_id in self._base_private_sources:
+            raise ValueError(
+                f"Cannot delete private table '{source_id}'. "
+                "Only views can be deleted."
+            )
 
         ref = find_reference(source_id, self._input_domain)
         if ref is None:

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -1648,6 +1648,15 @@ def setup_invalid_session_data(spark, request) -> None:
     request.cls.schema = schema
 
 
+    def test_delete_view_base_private_table_fails(self, session: Session):
+        """Tests that attempting to delete a base private table raises ValueError."""
+        with pytest.raises(
+            ValueError,
+            match="Cannot delete private table 'private'. Only views can be deleted.",
+        ):
+            session.delete_view("private")
+
+
 @pytest.mark.usefixtures("test_data_invalid")
 class TestInvalidSession:
     """Unit tests for invalid session."""


### PR DESCRIPTION
## Summary

Fixes #136.

`Session.delete_view` was not validating whether the given `source_id` referred to a view (dynamically created via `create_view`) or a base private table registered at Session construction time. This allowed callers to silently delete core private tables, which at best corrupts session state and at worst crashes with an unhelpful exception from tmlt-core when the last private table is deleted.

**Changes:**
- In `Session.__init__`, a new instance variable `_base_private_sources` is populated with the list of private table names present at session creation time.
- In `Session.delete_view`, a guard is added *before* the domain lookup: if `source_id` is in `_base_private_sources`, a `ValueError` is raised with a clear message: `Cannot delete private table '{source_id}'. Only views can be deleted.`

## Testing

- Added unit test `test_delete_view_base_private_table_fails` in `test/unit/test_session.py` verifying that calling `delete_view` on a base private table raises `ValueError` with the expected message.
- Existing tests for `delete_view` on views continue to pass unchanged.

## Issue Reference

Closes #136